### PR TITLE
fixed boost include for boost::units::detail::demangle

### DIFF
--- a/include/pion/error.hpp
+++ b/include/pion/error.hpp
@@ -19,6 +19,9 @@
 #include <boost/exception/info.hpp>
 #include <boost/exception/error_info.hpp>
 #include <boost/exception/get_error_info.hpp>
+#if BOOST_VERSION >= 104700
+#include <boost/units/io.hpp>
+#endif
 #include <pion/config.hpp>
 
 


### PR DESCRIPTION
Since 1.55 units/detail/utility.hpp can't be found through boost/exceptions (commented out).
Correct way to access boost::units::detail::demangle is to include boost/units
