### PR TITLE
fix for process_tests.cpp compilation

### DIFF
--- a/include/pion/process.hpp
+++ b/include/pion/process.hpp
@@ -19,6 +19,8 @@
 
 // Dump file generation support on Windows
 #ifdef _MSC_VER
+#include <windows.h>
+#include <tchar.h>
 #include <DbgHelp.h>
 // based on dbghelp.h
 typedef BOOL (WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -8,10 +8,7 @@
 //
 
 #include <signal.h>
-#ifdef _MSC_VER
-    #include <windows.h>
-    #include <tchar.h>
-#else
+#ifndef _MSC_VER
     #include <fcntl.h>
     #include <unistd.h>
     #include <sys/stat.h>


### PR DESCRIPTION
MSVS2012/WinSDK 8.0/CMake/Target 64bit

process_tests.cpp failed to compile with following error

21>  process_tests.cpp
21>C:\WORK\GITHUB\pion\include\pion/test/unit_test.hpp(57): warning C4100: 'test_cases_amount' : unreferenced formal parameter
21>C:\WORK\GITHUB\pion\include\pion/test/unit_test.hpp(253): warning C4267: 'initializing' : conversion from 'size_t' to 'long', possible loss of data
21>C:\Program Files (x86)\Windows Kits\8.0\Include\um\DbgHelp.h(77): error C2146: syntax error : missing ';' before identifier 'ModuleName'
21>C:\Program Files (x86)\Windows Kits\8.0\Include\um\DbgHelp.h(77): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
21>C:\Program Files (x86)\Windows Kits\8.0\Include\um\DbgHelp.h(78): error C2146: syntax error : missing ';' before identifier 'hFile'
21>C:\Program Files (x86)\Windows Kits\8.0\Include\um\DbgHelp.h(78): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
21>C:\Program Files (x86)\Windows Kits\8.0\Include\um\DbgHelp.h(79): error C2146: syntax error : missing ';' before identifier 'MappedAddress'

This because for project with tests windows.h was not included before dbghelp.h in process.hpp

So my proposal is put it in common .hpp file.
