### PR TITLE
shared_array<T>::operator bool() is explicit in boost 1.54, use static cast

### DIFF
--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -75,7 +75,7 @@ public:
     inline char *getFileContent(void) { return m_file_content.get(); }
 
     /// returns true if there is cached file content
-    inline bool hasFileContent(void) const { return m_file_content; }
+    inline bool hasFileContent(void) const { return static_cast<bool>(m_file_content); }
 
     /// returns size of the file's content
     inline unsigned long getFileSize(void) const { return m_file_size; }


### PR DESCRIPTION
Not sure which boost version otiginally introduced the explicit keyword. Tried with 1.54 and 1.55.
