### PR TITLE
Fixing RST stream status code logging.

### DIFF
--- a/include/pion/spdy/types.hpp
+++ b/include/pion/spdy/types.hpp
@@ -44,31 +44,6 @@ namespace spdy {    // begin namespace spdy
 #define HTTP_DATA                   3
 #define SPDY_CONTROL                4
 
-    
-/// SPDY value string data type
-typedef struct _value_string {
-    boost::uint32_t  value;
-    std::string   str;
-} value_string;
-
-    
-/// Int-String value pairs of the status code for the RST Stream
-static const value_string rst_stream_status_names[] = {
-    { 1,  "PROTOCOL_ERROR" },
-    { 2,  "INVALID_STREAM" },
-    { 3,  "REFUSED_STREAM" },
-    { 4,  "UNSUPPORTED_VERSION" },
-    { 5,  "CANCEL" },
-    { 6,  "INTERNAL_ERROR" },
-    { 7,  "FLOW_CONTROL_ERROR" },
-    { 8,  "STREAM_IN_USE" },
-    { 9,  "STREAM_ALREADY_CLOSED" },
-    { 10, "INVALID_CREDENTIALS" },
-    { 11, "FRAME_TOO_LARGE" },
-    { 12, "INVALID" },
-};
-    
-
 /// This structure will be tied to each SPDY frame
 typedef struct spdy_control_frame_info{
     bool control_bit;

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -20,6 +20,26 @@
 namespace pion {    // begin namespace pion
 namespace spdy {    // begin namespace spdy
 
+/// RST stream status string from code, return NULL for unknown status code
+static char const* rst_stream_status(boost::uint32_t rst_stream_status_code)
+{
+    switch (rst_stream_status_code)
+    {
+    case  1: return "PROTOCOL_ERROR";
+    case  2: return "INVALID_STREAM";
+    case  3: return "REFUSED_STREAM";
+    case  4: return "UNSUPPORTED_VERSION";
+    case  5: return "CANCEL";
+    case  6: return "INTERNAL_ERROR";
+    case  7: return "FLOW_CONTROL_ERROR";
+    case  8: return "STREAM_IN_USE";
+    case  9: return "STREAM_ALREADY_CLOSED";
+    case 10: return "INVALID_CREDENTIALS";
+    case 11: return "FRAME_TOO_LARGE";
+    case 12: return "INVALID";
+    default: return NULL;
+    }
+}
 
 parser::error_category_t *  parser::m_error_category_ptr = NULL;
 boost::once_flag            parser::m_instance_flag = BOOST_ONCE_INIT;
@@ -477,13 +497,9 @@ void parser::parse_spdy_rst_stream(boost::system::error_code &ec,
     
     status_code = algorithm::to_uint32(m_read_ptr);
     
-    // Check the index before using the stream status array
-    
-    if(status_code >=1 && status_code <= 12){
-    
-        PION_LOG_INFO(m_logger,
-                      "SPDY " << "Status Code is : "
-                      << rst_stream_status_names[status_code].str);
+    char const* const status_code_str = rst_stream_status(status_code);
+    if(status_code_str){
+        PION_LOG_INFO(m_logger, "SPDY Status Code is : " << status_code_str);
     }else{
         PION_LOG_INFO(m_logger, "SPDY RST Invalid status code : " << status_code);
     }


### PR DESCRIPTION
RST stream status codes were listed as a stream status array of pairs {code, string}.
And the code was used as an index in the status array instead of searching of pair
by the status code value.

This status codes array has been replaced with a rst_stream_status() function
that returns status string from a code or nullptr for unknown code.
