### PR TITLE
linux // added clang++ support

### DIFF
--- a/cmake/PionUtils.cmake
+++ b/cmake/PionUtils.cmake
@@ -37,6 +37,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -W")
     endif()
+    message("CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}")
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -W")
 endif()
 
 endmacro()


### PR DESCRIPTION
[snikulov@fedora20 b]$ CC=clang CXX=clang++ cmake .. -DBUILD_UT=ON -DBUILD_SPDY=ON
....
[snikulov@fedora20 b]$ make
...
In file included from /home/snikulov/work/github/pion/include/pion/hash_map.hpp:21:
In file included from /usr/lib/gcc/x86_64-redhat-linux/4.8.2/../../../../include/c++/4.8.2/unordered_map:35:
/usr/lib/gcc/x86_64-redhat-linux/4.8.2/../../../../include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: This file requires compiler and library
      support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11
      compiler options.
# error This file requires compiler and library support for the \

To fix this updated PionUtils.cmake to handle clang compiler id and set option "-std=c++11"
