### PR TITLE
Fixed incorrect usage of CMAKE_MODULE_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if (DOXYGEN_FOUND)
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 
-configure_file(${CMAKE_MODULE_PATH}/config.hpp.cmake ${COMMON_BIN_PATH}/pion/config.hpp)
+configure_file(${PION_SRC_ROOT}/cmake/config.hpp.cmake ${COMMON_BIN_PATH}/pion/config.hpp)
 include_directories(${COMMON_BIN_PATH})
 
 # TODO: handle #pragma comment, which is hardcoded in config.hpp


### PR DESCRIPTION
CMAKE_MODULE_PATH is a list of paths and in this 'configure_file'
line, only the last of the list is required. The modification ensures
that the 'cmake/config.hpp.cmake' file is used directly.

Without this patch, a cmake-time error occurs when CMAKE_MODULE_PATH
is nonempty before adding this 'CMakeLists.txt' file.
