### PR TITLE
Made 'include_directories' use correct boost include var.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ find_package(Boost COMPONENTS thread system filesystem regex unit_test_framework
 if (Boost_FOUND)
     # disable autolinking feature
     add_definitions(-DBOOST_ALL_NO_LIB)
-    include_directories(${Boost_INCLUDE_DIR})
+    include_directories(${Boost_INCLUDE_DIRS})
 else()
     message(FATAL_ERROR "Boost >= 1.35 required to build Pion")
 endif()


### PR DESCRIPTION
The documentation of FindBoost (cmake --help-module FindBoost)
indicates that 'Boost_INCLUDE_DIRS' points to the boost includes and not
'Boost_INCLUDE_DIR'.

This bug could inadvertently cause pion to use system boost headers with
another boost installation's libraries.