### PR TITLE
Add support for boost versions without 'BOOST_NOEXCEPT'.

### DIFF
--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -23,7 +23,13 @@
 #include <pion/http/types.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
-    #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
+    // if 'BOOST_NOEXCEPT' is not defined, as with some older versions of
+    // boost, setting it to nothing should be harmless.
+    #ifndef BOOST_NOEXCEPT
+        #define BOOST_SYSTEM_NOEXCEPT
+    #else
+        #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
+    #endif
 #endif
 
 


### PR DESCRIPTION
BOOST_NOEXCEPT is not in boost 1.47.0 in particular, which pion still
supports. Defining 'BOOST_SYSTEM_NOEXCEPT' to nothing in this case
will cause no harm.
