### PR TITLE
Use explicit CreateFileA function to create a dump file in Windows

### DIFF
--- a/include/pion/hash_map.hpp
+++ b/include/pion/hash_map.hpp
@@ -105,7 +105,7 @@ namespace pion {    // begin namespace pion
         }
     };
     
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && defined(PION_HAVE_EXT_HASH_MAP)
     /// Case-insensitive "less than" predicate
     template<class _Ty> struct is_iless : public std::binary_function<_Ty, _Ty, bool>
     {

--- a/include/pion/hash_map.hpp
+++ b/include/pion/hash_map.hpp
@@ -25,6 +25,8 @@
     #include <ext/hash_map>
 #elif defined(PION_HAVE_HASH_MAP)
     #include <hash_map>
+#else
+    #include <boost/unordered_map.hpp>
 #endif
 
 
@@ -62,6 +64,11 @@ namespace pion {    // begin namespace pion
         #define PION_HASH_STRING boost::hash<std::string>
         #define PION_HASH(TYPE) boost::hash<TYPE>
     #endif
+#else
+    #define PION_HASH_MAP boost::unordered_map
+    #define PION_HASH_MULTIMAP boost::unordered_multimap
+    #define PION_HASH_STRING boost::hash<std::string>
+    #define PION_HASH(TYPE) boost::hash<TYPE>
 #endif
 
     /// case insensitive string equality predicate

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -173,7 +173,7 @@ LONG WINAPI process::unhandled_exception_filter(struct _EXCEPTION_POINTERS *pExc
     LONG rc = EXCEPTION_CONTINUE_SEARCH;
 
     // create the dump file and, if successful, write it
-    HANDLE hFile = ::CreateFile(dumpfile_path.c_str(), GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS,
+    HANDLE hFile = ::CreateFileA(dumpfile_path.c_str(), GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS,
         FILE_ATTRIBUTE_NORMAL, NULL);
 
     if (hFile!=INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
  1. The dump file name is a std::string therefore `CreateFileA()` function should be used in order to compile in a Unicode project.

  2. Use boost::hash_map if no PION_HASH_MAP and PION_HASH_MULTIMAP has been configured

  3.  Define is_iless and ihash_windows for Visual C++ only if stdext::hash_multimap was configured as a ihash_multimap implementation