### PR TITLE
Replaced non-const reference arguments with value arguments for ptrs.

### DIFF
--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -47,9 +47,9 @@ public:
      * @return boost::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(tcp::connection_ptr& tcp_conn,
-                                                               http::response_ptr& http_response_ptr,
-                                                               finished_handler_t handler = finished_handler_t())
+    static inline boost::shared_ptr<response_writer> create(tcp::connection_ptr tcp_conn,
+                                                            http::response_ptr http_response_ptr,
+                                                            finished_handler_t handler = finished_handler_t())
     {
         return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_response_ptr, handler));
     }
@@ -64,9 +64,9 @@ public:
      * @return boost::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(tcp::connection_ptr& tcp_conn,
-                                                               const http::request& http_request,
-                                                               finished_handler_t handler = finished_handler_t())
+    static inline boost::shared_ptr<response_writer> create(tcp::connection_ptr tcp_conn,
+                                                            const http::request& http_request,
+                                                            finished_handler_t handler = finished_handler_t())
     {
         return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_request, handler));
     }
@@ -84,7 +84,7 @@ protected:
      * @param http_response pointer to the response that will be sent
      * @param handler function called after the request has been sent
      */
-    response_writer(tcp::connection_ptr& tcp_conn, http::response_ptr& http_response_ptr,
+    response_writer(tcp::connection_ptr tcp_conn, http::response_ptr http_response_ptr,
                        finished_handler_t handler)
         : http::writer(tcp_conn, handler), m_http_response(http_response_ptr)
     {
@@ -108,7 +108,7 @@ protected:
      * @param http_request the request we are responding to
      * @param handler function called after the request has been sent
      */
-    response_writer(tcp::connection_ptr& tcp_conn, const http::request& http_request,
+    response_writer(tcp::connection_ptr tcp_conn, const http::request& http_request,
                        finished_handler_t handler)
         : http::writer(tcp_conn, handler), m_http_response(new http::response(http_request))
     {

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -49,7 +49,7 @@ protected:
      * @param tcp_conn TCP connection used to send the message
      * @param handler function called after the request has been sent
      */
-    writer(tcp::connection_ptr& tcp_conn, finished_handler_t handler)
+    writer(tcp::connection_ptr tcp_conn, finished_handler_t handler)
         : m_logger(PION_GET_LOGGER("pion.http.writer")),
         m_tcp_conn(tcp_conn), m_content_length(0), m_stream_is_empty(true), 
         m_client_supports_chunks(true), m_sending_chunks(false),


### PR DESCRIPTION
These functions were only making copies of these arguments. There wasn't
any modification. This commit made these arguments value-types instead
to be more flexible to calling code.