### PR TITLE
Fix some mingw compatibility issues

### DIFF
--- a/include/pion/process.hpp
+++ b/include/pion/process.hpp
@@ -18,10 +18,10 @@
 #include <pion/config.hpp>
 
 // Dump file generation support on Windows
-#ifdef _MSC_VER
+#ifdef PION_WIN32
 #include <windows.h>
 #include <tchar.h>
-#include <DbgHelp.h>
+#include <dbghelp.h>
 // based on dbghelp.h
 typedef BOOL (WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
 									CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
@@ -57,14 +57,16 @@ public:
     /// fork process and run as a background daemon
     static void daemonize(void);
 
-#ifdef _MSC_VER
+#ifdef PION_WIN32
 
     class dumpfile_init_exception : public std::exception
     {
     public:
         dumpfile_init_exception(const std::string& cause) : m_cause(cause) {}
 
-        virtual const char* what() const { return m_cause.c_str(); }
+	virtual ~dumpfile_init_exception() throw () {}
+
+        virtual const char* what() const throw () { return m_cause.c_str(); }
     protected:
         std::string m_cause;
     };
@@ -89,7 +91,7 @@ protected:
     /// data type for static/global process configuration information
     struct config_type {
         /// constructor just initializes native types
-#ifdef _MSC_VER
+#ifdef PION_WIN32
         config_type() : shutdown_now(false), h_dbghelp(NULL), p_dump_proc(NULL) {}
 #else
         config_type() : shutdown_now(false) {}
@@ -105,7 +107,7 @@ protected:
         boost::mutex            shutdown_mutex;
 
 // Dump file generation support on Windows
-#ifdef _MSC_VER
+#ifdef PION_WIN32
         /// mini-dump file location
         std::string             dumpfile_dir;
         

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -9,7 +9,7 @@
 
 #include <pion/admin_rights.hpp>
 
-#ifndef _MSC_VER
+#ifndef PION_WIN32
     #include <sys/types.h>
     #include <unistd.h>
     #include <sys/types.h>
@@ -31,7 +31,7 @@ boost::mutex            admin_rights::m_mutex;
 
 // admin_rights member functions
 
-#ifdef _MSC_VER
+#ifdef PION_WIN32
 
 admin_rights::admin_rights(bool use_log)
     : m_logger(PION_GET_LOGGER("pion.admin_rights")),
@@ -57,7 +57,7 @@ long admin_rights::find_system_id(const std::string& name,
     return -1;
 }
 
-#else   // NOT #ifdef _MSC_VER
+#else   // NOT #ifdef PION_WIN32
 
 admin_rights::admin_rights(bool use_log)
     : m_logger(PION_GET_LOGGER("pion.admin_rights")),
@@ -154,7 +154,7 @@ long admin_rights::find_system_id(const std::string& name,
     return system_id;
 }
 
-#endif  // #ifdef _MSC_VER
+#endif  // #ifdef PION_WIN32
     
 }   // end namespace pion
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -8,7 +8,7 @@
 //
 
 #include <signal.h>
-#ifndef _MSC_VER
+#ifndef PION_WIN32
     #include <fcntl.h>
     #include <unistd.h>
     #include <sys/stat.h>
@@ -57,7 +57,7 @@ void process::create_config(void)
 
 
 
-#ifdef _MSC_VER
+#ifdef PION_WIN32
 
 BOOL WINAPI console_ctrl_handler(DWORD ctrl_type)
 {
@@ -217,7 +217,7 @@ void process::daemonize(void)
     // not supported
 }
 
-#else   // NOT #ifdef _MSC_VER
+#else   // NOT #ifdef PION_WIN32
 
 void handle_signal(int sig)
 {
@@ -268,6 +268,6 @@ void process::daemonize(void)
     umask(027);
 }
 
-#endif  // #ifdef _MSC_VER
+#endif  // #ifdef PION_WIN32
 
 }   // end namespace pion


### PR DESCRIPTION
In many cases pion checks for the MSVC compiler when it really means to be checking if the target is WIN32.

This PR does not fix the config.h file as we have customized it in our environment and cannot test it. Suffice it to say, config.h checks for _MSC_VER and should not. It is also safe for it to be added to the linux config.h since _WIN32 will not be defined.