### PR TITLE
PION-1325: VS workaround in hash_map.hpp doesn't work for VS 2013

### DIFF
--- a/include/pion/config.hpp.win
+++ b/include/pion/config.hpp.win
@@ -51,6 +51,9 @@
 
 /* Define to 1 if you have the <unordered_map> header file. */
 #undef PION_HAVE_UNORDERED_MAP
+#if defined(_MSC_VER) && (_MSC_VER >= 1600)
+#define PION_HAVE_UNORDERED_MAP 1
+#endif
 
 // -----------------------------------------------------------------------
 // Logging Options

--- a/include/pion/hash_map.hpp
+++ b/include/pion/hash_map.hpp
@@ -97,7 +97,7 @@ namespace pion {    // begin namespace pion
         }
     };
     
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(PION_HAVE_UNORDERED_MAP)
     /// Case-insensitive "less than" predicate
     template<class _Ty> struct is_iless : public std::binary_function<_Ty, _Ty, bool>
     {


### PR DESCRIPTION
Now uses std::unordered_multimap for _MSC_VER >= 1600 (i.e. VS >= 2010).
