### PR TITLE
Fixed boost_unit_test_framework detection on Debian family

### DIFF
--- a/build/pion-boost.inc
+++ b/build/pion-boost.inc
@@ -134,25 +134,22 @@ if test "x$enable_tests" == "xno"; then
 	# Display notice if unit tests are disabled
 	AC_MSG_NOTICE([Unit tests are disabled])
 else
-	BOOST_TRY_LIB=unit_test_framework
-	BOOST_TRY_LINK="$BOOST_HOME_DIR/lib/libboost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}.a"
 	# check if static version of lib is available
-	if !(test -r "$BOOST_TRY_LINK"); then
-	    BOOST_TRY_LINK="-lboost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}"
-	    PION_TESTS_CPPFLAGS="-DBOOST_TEST_DYN_LINK"
-	fi
+	BOOST_TRY_LIB=unit_test_framework
+	BOOST_TRY_LINK="boost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}"
+	PION_TESTS_CPPFLAGS="-DBOOST_TEST_DYN_LINK"
 	LIBS_SAVED="$LIBS"
-	LIBS="$LIBS_SAVED ${BOOST_TRY_LINK}"
+	LIBS="$LIBS_SAVED -l${BOOST_TRY_LINK}"
 	CPPFLAGS_SAVED="$CPPFLAGS"
 	CPPFLAGS="$CPPFLAGS ${PION_TESTS_CPPFLAGS}"
 	AC_MSG_CHECKING([for boost::test library])
 	AC_TRY_LINK([#include <boost/test/unit_test.hpp>
 		using namespace boost::unit_test;
-		test_suite* init_unit_test_suite( int argc, char* argv[] )
+		test_suite* init_unit_test_suite( int, char** )
 		{ return BOOST_TEST_SUITE("Master test suite"); }],
 		[],
 		[ AC_MSG_RESULT(ok)
-		  BOOST_TEST_LIB="${BOOST_TRY_LINK}"
+		  BOOST_TEST_LIB="-l${BOOST_TRY_LINK}"
 		],
 		[ AC_MSG_RESULT(not found)
 		  AC_MSG_ERROR(Unable to link with the boost::${BOOST_TRY_LIB} library)


### PR DESCRIPTION
  On Debian, since the multi-arch transition, the boost libraries
  are located in architecture specific directores. For example
  /usr/lib/x86_64-linux-gnu/libboost*

  This patch removes the hard coded library path and leaves it to
  the linker to look in all the normal locations.
