### PR TITLE
Adds cmake package configuration and version file to enable find_package(libpion)

### DIFF
--- a/cmake/modules/libpion-config.cmake.in
+++ b/cmake/modules/libpion-config.cmake.in
@@ -1,0 +1,22 @@
+# libpion @LIBPION_LIBRARY_VERSION@ - CMake Package Configuration File
+#
+#   To use libpion in your software, simply add the following to your 
+#   CMakeLists.txt :
+#
+#       find_package(libpion @LIBPION_LIBRARY_VERSION@ REQUIRED)
+#       link_directories(${LIBPION_LIBRARY_DIRS}) 
+#       include_directories(${LIBPION_INCLUDE_DIRS})
+#
+#   Once this done you can simply add *pion* to your target_link_libraries, e.g:
+#       target_link_libraries(yourTarget ${LIBPION_LIBRARIES})
+#       
+
+set(LIBPION_VERSION_MAJOR @PION_V_MAJOR@)
+set(LIBPION_VERSION_MINOR @PION_V_MINOR@)
+set(LIBPION_VERSION_PATCH @PION_V_PATCH@)
+set(LIBPION_PACKAGE_VERSION @PION_VERSION@)
+
+set(LIBPION_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@")
+set(LIBPION_INCLUDE_DIRS ${LIBPION_INSTALL_PREFIX}/include)
+set(LIBPION_LIBRARY_DIRS ${LIBPION_INSTALL_PREFIX}/lib)
+set(LIBPION_LIBRARIES ${LIBPION_INSTALL_PREFIX}/lib/libpion@CMAKE_SHARED_MODULE_SUFFIX@)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,3 +54,17 @@ install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION lib
 )
 
+include(CMakePackageConfigHelpers)
+configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/lib${PROJECT_NAME}-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}-config.cmake
+    @ONLY)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}-config-version.cmake
+    VERSION ${PION_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}-config-version.cmake
+    DESTINATION lib/cmake/lib${PROJECT_NAME}-${PION_VERSION})


### PR DESCRIPTION
Hi dear splunk developers team,

I was just about to use your library in my project and noticed that your cmake build didn't add package-config, but personally I wished to be able to find_package pion, so I simply added the necessary steps for this.

This allows users of the library to include it easily then :
       find_package(libpion 5.0.6 REQUIRED)
       link_directories(${LIBPION_LIBRARY_DIRS})
       include_directories(${LIBPION_INCLUDE_DIRS})
       target_link_libraries(yourTarget ${LIBPION_LIBRARIES})

It also has the advantages that if different version are on the system, only the right one is taken. 

Thanks for this http library :smiley: 
Cheers,