### PR TITLE
Fix compilation error when Boost < 1.50

### DIFF
--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -21,7 +21,11 @@
 #include <pion/spdy/decompressor.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
-    #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
+    #ifndef BOOST_NOEXCEPT
+        #define BOOST_SYSTEM_NOEXCEPT
+    #else
+        #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
+    #endif
 #endif
 
 


### PR DESCRIPTION
Define `BOOST_SYSTEM_NOEXCEPT` as `BOOST_NOEXCEPT` only if the
latter is defined. Close #79.