### PR TITLE
Fix PION_GET_LOGGER definition for log4cxx

### DIFF
--- a/include/pion/logger.hpp
+++ b/include/pion/logger.hpp
@@ -49,7 +49,7 @@
     #define PION_HAS_LOG_APPENDER   1
     #define PION_LOG_CONFIG_BASIC   log4cxx::BasicConfigurator::configure();
     #define PION_LOG_CONFIG(FILE)   log4cxx::PropertyConfigurator::configure(FILE);
-    #define PION_GET_LOGGER(NAME)   log4cxx::Logger::get_logger(NAME)
+    #define PION_GET_LOGGER(NAME)   log4cxx::Logger::getLogger(NAME)
     #define PION_SHUTDOWN_LOGGER    log4cxx::LogManager::shutdown();
 
     #define PION_LOG_SETLEVEL_DEBUG(LOG)    LOG->setLevel(log4cxx::Level::toLevel(log4cxx::Level::DEBUG_INT));


### PR DESCRIPTION
Macro `PION_GET_LOGGER` is incorrectly defined in logger.hpp for log4cxx.
Close #14.