### PR TITLE
Set 'ec' error code argument if badbit or failbit set during write.

### DIFF
--- a/src/http_message.cpp
+++ b/src/http_message.cpp
@@ -171,6 +171,10 @@ std::size_t message::write(std::ostream& out,
         const char *ptr = boost::asio::buffer_cast<const char*>(*i);
         size_t len = boost::asio::buffer_size(*i);
         out.write(ptr, len);
+        if (!out) {
+          ec = make_error_code(boost::system::errc::io_error);
+          break;
+        }
         bytes_out += len;
     }
 


### PR DESCRIPTION
Write function of 'pion::http::message' does not set 'ec' error code if failbit or badbit set. Discussion here:
http://sourceforge.net/p/pion/mailman/message/33332692/