### PR TITLE
Change boost::shared_ptr typedefs that are passed to functions by reference to const-ref.

### DIFF
--- a/include/pion/http/auth.hpp
+++ b/include/pion/http/auth.hpp
@@ -57,7 +57,7 @@ public:
      *
      * @return true if request valid and user identity inserted into request 
      */
-    virtual bool handle_request(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn) = 0;
+    virtual bool handle_request(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn) = 0;
     
     /**
      * sets a configuration option

--- a/include/pion/http/basic_auth.hpp
+++ b/include/pion/http/basic_auth.hpp
@@ -46,7 +46,7 @@ public:
      *
      * @return true if request valid and user identity inserted into request 
      */
-    virtual bool handle_request(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn);
+    virtual bool handle_request(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn);
     
     /**
      * sets a configuration option
@@ -67,7 +67,7 @@ protected:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    void handle_unauthorized(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn);
+    void handle_unauthorized(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn);
     
     /**
      * extracts base64 user credentials from authorization string

--- a/include/pion/http/cookie_auth.hpp
+++ b/include/pion/http/cookie_auth.hpp
@@ -66,7 +66,7 @@ public:
      *
      * @return true if request valid and user identity inserted into request 
      */
-    virtual bool handle_request(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn);
+    virtual bool handle_request(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn);
     
     /**
      * sets a configuration option
@@ -94,7 +94,7 @@ protected:
      *
      * @return true if it was a login/logout request and no future processing required.
      */
-    bool process_login(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn);
+    bool process_login(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn);
 
     /**
      * used to send responses when access to resource is not authorized
@@ -102,7 +102,7 @@ protected:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    void handle_unauthorized(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn);
+    void handle_unauthorized(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn);
     
     /**
      * used to send redirection responses 
@@ -110,7 +110,7 @@ protected:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    void handle_redirection(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn,
+    void handle_redirection(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn,
         const std::string &redirection_url, const std::string &new_cookie="", bool delete_cookie=false);
 
     /**
@@ -119,7 +119,7 @@ protected:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    void handle_ok(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn,
+    void handle_ok(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn,
         const std::string &new_cookie="", bool delete_cookie=false);
 
     /**

--- a/include/pion/http/plugin_service.hpp
+++ b/include/pion/http/plugin_service.hpp
@@ -43,7 +43,7 @@ public:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    virtual void operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn) = 0;
+    virtual void operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn) = 0;
     
     /**
      * sets a configuration option

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -52,7 +52,7 @@ protected:
      *                   if false, the message is parsed as an HTTP response
      * @param tcp_conn TCP connection containing a new message to parse
      */
-    reader(const bool is_request, tcp::connection_ptr& tcp_conn)
+    reader(const bool is_request, const tcp::connection_ptr& tcp_conn)
         : http::parser(is_request), m_tcp_conn(tcp_conn),
         m_read_timeout(DEFAULT_READ_TIMEOUT)
         {}  

--- a/include/pion/http/request_reader.hpp
+++ b/include/pion/http/request_reader.hpp
@@ -50,7 +50,7 @@ public:
      * @param handler function called after the message has been parsed
      */
     static inline boost::shared_ptr<request_reader>
-        create(tcp::connection_ptr& tcp_conn, finished_handler_t handler)
+        create(const tcp::connection_ptr& tcp_conn, finished_handler_t handler)
     {
         return boost::shared_ptr<request_reader>
             (new request_reader(tcp_conn, handler));
@@ -68,7 +68,7 @@ protected:
      * @param tcp_conn TCP connection containing a new message to parse
      * @param handler function called after the message has been parsed
      */
-    request_reader(tcp::connection_ptr& tcp_conn, finished_handler_t handler)
+    request_reader(const tcp::connection_ptr& tcp_conn, finished_handler_t handler)
         : http::reader(true, tcp_conn), m_http_msg(new http::request),
         m_finished(handler)
     {

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -45,7 +45,7 @@ public:
      * @return boost::shared_ptr<request_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<request_writer> create(tcp::connection_ptr& tcp_conn,
+    static inline boost::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
                                                               finished_handler_t handler = finished_handler_t())
     {
         return boost::shared_ptr<request_writer>(new request_writer(tcp_conn, handler));
@@ -61,8 +61,8 @@ public:
      * @return boost::shared_ptr<request_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<request_writer> create(tcp::connection_ptr& tcp_conn,
-                                                              http::request_ptr& http_request_ptr,
+    static inline boost::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
+                                                              const http::request_ptr& http_request_ptr,
                                                               finished_handler_t handler = finished_handler_t())
     {
         return boost::shared_ptr<request_writer>(new request_writer(tcp_conn, http_request_ptr, handler));
@@ -80,7 +80,7 @@ protected:
      * @param tcp_conn TCP connection used to send the request
      * @param handler function called after the request has been sent
      */
-    request_writer(tcp::connection_ptr& tcp_conn, finished_handler_t handler)
+    request_writer(const tcp::connection_ptr& tcp_conn, finished_handler_t handler)
         : http::writer(tcp_conn, handler), m_http_request(new http::request)
     {
         set_logger(PION_GET_LOGGER("pion.http.request_writer"));
@@ -93,7 +93,7 @@ protected:
      * @param http_request_ptr pointer to the request that will be sent
      * @param handler function called after the request has been sent
      */
-    request_writer(tcp::connection_ptr& tcp_conn, http::request_ptr& http_request_ptr,
+    request_writer(const tcp::connection_ptr& tcp_conn, const http::request_ptr& http_request_ptr,
                       finished_handler_t handler)
         : http::writer(tcp_conn, handler), m_http_request(http_request_ptr)
     {

--- a/include/pion/http/response_reader.hpp
+++ b/include/pion/http/response_reader.hpp
@@ -51,7 +51,7 @@ public:
      * @param handler function called after the message has been parsed
      */
     static inline boost::shared_ptr<response_reader>
-        create(tcp::connection_ptr& tcp_conn, const http::request& http_request,
+        create(const tcp::connection_ptr& tcp_conn, const http::request& http_request,
                finished_handler_t handler)
     {
         return boost::shared_ptr<response_reader>
@@ -71,7 +71,7 @@ protected:
      * @param http_request the request we are responding to
      * @param handler function called after the message has been parsed
      */
-    response_reader(tcp::connection_ptr& tcp_conn, const http::request& http_request,
+    response_reader(const tcp::connection_ptr& tcp_conn, const http::request& http_request,
                        finished_handler_t handler)
         : http::reader(false, tcp_conn), m_http_msg(new http::response(http_request)),
         m_finished(handler)

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -47,8 +47,8 @@ public:
      * @return boost::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(tcp::connection_ptr& tcp_conn,
-                                                               http::response_ptr& http_response_ptr,
+    static inline boost::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
+                                                               const http::response_ptr& http_response_ptr,
                                                                finished_handler_t handler = finished_handler_t())
     {
         return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_response_ptr, handler));
@@ -64,7 +64,7 @@ public:
      * @return boost::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(tcp::connection_ptr& tcp_conn,
+    static inline boost::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
                                                                const http::request& http_request,
                                                                finished_handler_t handler = finished_handler_t())
     {
@@ -84,7 +84,7 @@ protected:
      * @param http_response pointer to the response that will be sent
      * @param handler function called after the request has been sent
      */
-    response_writer(tcp::connection_ptr& tcp_conn, http::response_ptr& http_response_ptr,
+    response_writer(const tcp::connection_ptr& tcp_conn, const http::response_ptr& http_response_ptr,
                        finished_handler_t handler)
         : http::writer(tcp_conn, handler), m_http_response(http_response_ptr)
     {
@@ -108,7 +108,7 @@ protected:
      * @param http_request the request we are responding to
      * @param handler function called after the request has been sent
      */
-    response_writer(tcp::connection_ptr& tcp_conn, const http::request& http_request,
+    response_writer(const tcp::connection_ptr& tcp_conn, const http::request& http_request,
                        finished_handler_t handler)
         : http::writer(tcp_conn, handler), m_http_response(new http::response(http_request))
     {

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -40,10 +40,10 @@ class PION_API server :
 public:
 
     /// type of function that is used to handle requests
-    typedef boost::function2<void, http::request_ptr&, tcp::connection_ptr&>  request_handler_t;
+    typedef boost::function2<void, const http::request_ptr&, const tcp::connection_ptr&>  request_handler_t;
 
     /// handler for requests that result in "500 Server Error"
-    typedef boost::function3<void, http::request_ptr&, tcp::connection_ptr&,
+    typedef boost::function3<void, const http::request_ptr&, const tcp::connection_ptr&,
         const std::string&> error_handler_t;
 
 
@@ -170,8 +170,8 @@ public:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    static void handle_bad_request(http::request_ptr& http_request_ptr,
-                                 tcp::connection_ptr& tcp_conn);
+    static void handle_bad_request(const http::request_ptr& http_request_ptr,
+                                 const tcp::connection_ptr& tcp_conn);
 
     /**
      * used to send responses when no web services can handle the request
@@ -179,8 +179,8 @@ public:
      * @param http_request_ptr the new HTTP request to handle
      * @param tcp_conn the TCP connection that has the new request
      */
-    static void handle_not_found_request(http::request_ptr& http_request_ptr,
-                                      tcp::connection_ptr& tcp_conn);
+    static void handle_not_found_request(const http::request_ptr& http_request_ptr,
+                                      const tcp::connection_ptr& tcp_conn);
 
     /**
      * used to send responses when a server error occurs
@@ -189,8 +189,8 @@ public:
      * @param tcp_conn the TCP connection that has the new request
      * @param error_msg message that explains what went wrong
      */
-    static void handle_server_error(http::request_ptr& http_request_ptr,
-                                  tcp::connection_ptr& tcp_conn,
+    static void handle_server_error(const http::request_ptr& http_request_ptr,
+                                  const tcp::connection_ptr& tcp_conn,
                                   const std::string& error_msg);
 
     /**
@@ -200,8 +200,8 @@ public:
      * @param tcp_conn the TCP connection that has the new request
      * @param error_msg message that explains what went wrong
      */
-    static void handle_forbidden_request(http::request_ptr& http_request_ptr,
-                                       tcp::connection_ptr& tcp_conn,
+    static void handle_forbidden_request(const http::request_ptr& http_request_ptr,
+                                       const tcp::connection_ptr& tcp_conn,
                                        const std::string& error_msg);
 
     /**
@@ -211,8 +211,8 @@ public:
      * @param tcp_conn the TCP connection that has the new request
      * @param allowed_methods optional comma separated list of allowed methods
      */
-    static void handle_method_not_allowed(http::request_ptr& http_request_ptr,
-                                       tcp::connection_ptr& tcp_conn,
+    static void handle_method_not_allowed(const http::request_ptr& http_request_ptr,
+                                       const tcp::connection_ptr& tcp_conn,
                                        const std::string& allowed_methods = "");
 
     /**
@@ -230,7 +230,7 @@ protected:
      * 
      * @param tcp_conn the new TCP connection to handle
      */
-    virtual void handle_connection(tcp::connection_ptr& tcp_conn);
+    virtual void handle_connection(const tcp::connection_ptr& tcp_conn);
 
     /**
      * handles a new HTTP request
@@ -239,8 +239,8 @@ protected:
      * @param tcp_conn TCP connection containing a new request
      * @param ec error_code contains additional information for parsing errors
      */
-    virtual void handle_request(http::request_ptr& http_request_ptr,
-                                tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec);
+    virtual void handle_request(const http::request_ptr& http_request_ptr,
+                                const tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec);
 
     /**
      * searches for the appropriate request handler to use for a given resource

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -49,7 +49,7 @@ protected:
      * @param tcp_conn TCP connection used to send the message
      * @param handler function called after the request has been sent
      */
-    writer(tcp::connection_ptr& tcp_conn, finished_handler_t handler)
+    writer(const tcp::connection_ptr& tcp_conn, finished_handler_t handler)
         : m_logger(PION_GET_LOGGER("pion.http.writer")),
         m_tcp_conn(tcp_conn), m_content_length(0), m_stream_is_empty(true), 
         m_client_supports_chunks(true), m_sending_chunks(false),

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -85,7 +85,7 @@ public:
      */
     boost::tribool parse(http_protocol_info& http_headers,
                          boost::system::error_code& ec,
-                         decompressor_ptr& decompressor,
+                         const decompressor_ptr& decompressor,
                          const char *packet_ptr,
                          boost::uint32_t& length_packet,
                          boost::uint32_t current_stream_count);
@@ -155,7 +155,7 @@ protected:
      *
      */
     void parse_header_payload(boost::system::error_code& ec,
-                              decompressor_ptr& decompressor,
+                              const decompressor_ptr& decompressor,
                               const spdy_control_frame_info& frame,
                               http_protocol_info& http_headers,
                               boost::uint32_t current_stream_count);
@@ -213,7 +213,7 @@ protected:
      *                        indeterminate = not yet finished parsing SPDY frame
      */
     boost::tribool parse_spdy_frame(boost::system::error_code& ec,
-                                    decompressor_ptr& decompressor,
+                                    const decompressor_ptr& decompressor,
                                     http_protocol_info& http_headers,
                                     boost::uint32_t& length_packet,
                                     boost::uint32_t current_stream_count);

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -141,7 +141,7 @@ protected:
      * 
      * @param tcp_conn the new TCP connection to handle
      */
-    virtual void handle_connection(tcp::connection_ptr& tcp_conn) {
+    virtual void handle_connection(const tcp::connection_ptr& tcp_conn) {
         tcp_conn->set_lifecycle(connection::LIFECYCLE_CLOSE); // make sure it will get closed
         tcp_conn->finish();
     }
@@ -174,7 +174,7 @@ private:
      * @param tcp_conn the new TCP connection (if no error occurred)
      * @param accept_error true if an error occurred while accepting connections
      */
-    void handle_accept(tcp::connection_ptr& tcp_conn,
+    void handle_accept(const tcp::connection_ptr& tcp_conn,
                       const boost::system::error_code& accept_error);
 
     /**
@@ -183,14 +183,14 @@ private:
      * @param tcp_conn the new TCP connection (if no error occurred)
      * @param handshake_error true if an error occurred during the SSL handshake
      */
-    void handle_ssl_handshake(tcp::connection_ptr& tcp_conn,
+    void handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
                             const boost::system::error_code& handshake_error);
     
     /// This will be called by connection::finish() after a server has
     /// finished handling a connection.  If the keep_alive flag is true,
     /// it will call handle_connection(); otherwise, it will close the
     /// connection and remove it from the server's management pool
-    void finish_connection(tcp::connection_ptr& tcp_conn);
+    void finish_connection(const tcp::connection_ptr& tcp_conn);
     
     /// prunes orphaned connections that did not close cleanly
     /// and returns the remaining number of connections in the pool

--- a/include/pion/tcp/stream.hpp
+++ b/include/pion/tcp/stream.hpp
@@ -53,7 +53,7 @@ public:
      *
      * @param conn_ptr pointer to the TCP connection to use for reading & writing
      */
-    explicit stream_buffer(tcp::connection_ptr& conn_ptr)
+    explicit stream_buffer(const tcp::connection_ptr& conn_ptr)
         : m_conn_ptr(conn_ptr), m_read_buf(m_conn_ptr->get_read_buffer().c_array())
     {
         setup_buffers();
@@ -338,7 +338,7 @@ public:
      *
      * @param conn_ptr pointer to the TCP connection to use for reading & writing
      */
-    explicit stream(tcp::connection_ptr& conn_ptr)
+    explicit stream(const tcp::connection_ptr& conn_ptr)
         : std::basic_iostream<char, std::char_traits<char> >(NULL), m_tcp_buf(conn_ptr)
     {
         // initialize basic_iostream with pointer to the stream buffer

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -36,7 +36,7 @@ public:
      *
      * @param conn_ptr pointer to TCP connection to monitor
      */
-    timer(tcp::connection_ptr& conn_ptr);
+    timer(const tcp::connection_ptr& conn_ptr);
 
     /**
      * starts a timer for closing a TCP connection

--- a/services/AllowNothingService.cpp
+++ b/services/AllowNothingService.cpp
@@ -17,7 +17,7 @@ namespace pion {        // begin namespace pion
 namespace plugins {     // begin namespace plugins
 
     
-void AllowNothingService::operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+void AllowNothingService::operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     static const std::string DENY_HTML = "<html><body>No, you can't.</body></html>";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,

--- a/services/AllowNothingService.hpp
+++ b/services/AllowNothingService.hpp
@@ -25,8 +25,8 @@ class AllowNothingService : public pion::http::plugin_service
 public:
     AllowNothingService(void) {}
     ~AllowNothingService() {}
-    virtual void operator()(pion::http::request_ptr& http_request_ptr,
-                            pion::tcp::connection_ptr& tcp_conn);
+    virtual void operator()(const pion::http::request_ptr& http_request_ptr,
+                            const pion::tcp::connection_ptr& tcp_conn);
 };
     
 }   // end namespace plugins

--- a/services/CookieService.cpp
+++ b/services/CookieService.cpp
@@ -20,7 +20,7 @@ namespace plugins {     // begin namespace plugins
 // CookieService member functions
 
 /// handles requests for CookieService
-void CookieService::operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+void CookieService::operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     static const std::string HEADER_HTML = "<html>\n<head>\n<title>Cookie Service</title>\n"
         "</head>\n<body>\n\n<h1>Cookie Service</h1>\n";

--- a/services/CookieService.hpp
+++ b/services/CookieService.hpp
@@ -25,8 +25,8 @@ class CookieService :
 public:
     CookieService(void) {}
     virtual ~CookieService() {}
-    virtual void operator()(pion::http::request_ptr& http_request_ptr,
-                            pion::tcp::connection_ptr& tcp_conn);
+    virtual void operator()(const pion::http::request_ptr& http_request_ptr,
+                            const pion::tcp::connection_ptr& tcp_conn);
 };
 
 }   // end namespace plugins

--- a/services/EchoService.cpp
+++ b/services/EchoService.cpp
@@ -33,7 +33,7 @@ void writeDictionaryTerm(http::response_writer_ptr& writer,
 // EchoService member functions
 
 /// handles requests for EchoService
-void EchoService::operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+void EchoService::operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     // this web service uses static text to test the mixture of "copied" with
     // "static" (no-copy) text

--- a/services/EchoService.hpp
+++ b/services/EchoService.hpp
@@ -25,8 +25,8 @@ class EchoService :
 public:
     EchoService(void) {}
     virtual ~EchoService() {}
-    virtual void operator()(pion::http::request_ptr& http_request_ptr,
-                            pion::tcp::connection_ptr& tcp_conn);
+    virtual void operator()(const pion::http::request_ptr& http_request_ptr,
+                            const pion::tcp::connection_ptr& tcp_conn);
 };
 
 }   // end namespace plugins

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -114,7 +114,7 @@ void FileService::set_option(const std::string& name, const std::string& value)
     }
 }
 
-void FileService::operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+void FileService::operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     // get the relative resource path for the request
     const std::string relative_path(get_relative_resource(http_request_ptr->get_resource()));
@@ -565,8 +565,8 @@ void FileService::operator()(http::request_ptr& http_request_ptr, tcp::connectio
     }
 }
 
-void FileService::sendNotFoundResponse(http::request_ptr& http_request_ptr,
-                                       tcp::connection_ptr& tcp_conn)
+void FileService::sendNotFoundResponse(const http::request_ptr& http_request_ptr,
+                                       const tcp::connection_ptr& tcp_conn)
 {
     static const std::string NOT_FOUND_HTML_START =
         "<html><head>\n"
@@ -810,8 +810,8 @@ bool DiskFile::checkUpdated(void)
 
 // DiskFileSender member functions
 
-DiskFileSender::DiskFileSender(DiskFile& file, pion::http::request_ptr& http_request_ptr,
-                               pion::tcp::connection_ptr& tcp_conn,
+DiskFileSender::DiskFileSender(DiskFile& file, const pion::http::request_ptr& http_request_ptr,
+                               const pion::tcp::connection_ptr& tcp_conn,
                                unsigned long max_chunk_size)
     : m_logger(PION_GET_LOGGER("pion.FileService.DiskFileSender")), m_disk_file(file),
     m_writer(pion::http::response_writer::create(tcp_conn, *http_request_ptr, boost::bind(&tcp::connection::finish, tcp_conn))),

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -145,8 +145,8 @@ public:
      */
     static inline boost::shared_ptr<DiskFileSender>
         create(DiskFile& file,
-               pion::http::request_ptr& http_request_ptr,
-               pion::tcp::connection_ptr& tcp_conn,
+               const pion::http::request_ptr& http_request_ptr,
+               const pion::tcp::connection_ptr& tcp_conn,
                unsigned long max_chunk_size = 0) 
     {
         return boost::shared_ptr<DiskFileSender>(new DiskFileSender(file, http_request_ptr,
@@ -179,8 +179,8 @@ protected:
      * @param max_chunk_size sets the maximum chunk size
      */
     DiskFileSender(DiskFile& file,
-                   pion::http::request_ptr& http_request_ptr,
-                   pion::tcp::connection_ptr& tcp_conn,
+                   const pion::http::request_ptr& http_request_ptr,
+                   const pion::tcp::connection_ptr& tcp_conn,
                    unsigned long max_chunk_size);
 
     /**
@@ -254,8 +254,8 @@ public:
     virtual void set_option(const std::string& name, const std::string& value);
 
     /// handles requests for FileService
-    virtual void operator()(pion::http::request_ptr& http_request_ptr,
-                            pion::tcp::connection_ptr& tcp_conn);
+    virtual void operator()(const pion::http::request_ptr& http_request_ptr,
+                            const pion::tcp::connection_ptr& tcp_conn);
 
     /// called when the web service's server is starting
     virtual void start(void);
@@ -308,8 +308,8 @@ protected:
      */
     static std::string findMIMEType(const std::string& file_name);
 
-    void sendNotFoundResponse(pion::http::request_ptr& http_request_ptr,
-                              pion::tcp::connection_ptr& tcp_conn);
+    void sendNotFoundResponse(const pion::http::request_ptr& http_request_ptr,
+                              const pion::tcp::connection_ptr& tcp_conn);
 
     /// primary logging interface used by this class
     logger                  m_logger;

--- a/services/HelloService.cpp
+++ b/services/HelloService.cpp
@@ -19,7 +19,7 @@ namespace plugins {     // begin namespace plugins
 // HelloService member functions
 
 /// handles requests for HelloService
-void HelloService::operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+void HelloService::operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     static const std::string HELLO_HTML = "<html><body>Hello World!</body></html>";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,

--- a/services/HelloService.hpp
+++ b/services/HelloService.hpp
@@ -25,8 +25,8 @@ class HelloService :
 public:
     HelloService(void) {}
     virtual ~HelloService() {}
-    virtual void operator()(pion::http::request_ptr& http_request_ptr,
-                            pion::tcp::connection_ptr& tcp_conn);
+    virtual void operator()(const pion::http::request_ptr& http_request_ptr,
+                            const pion::tcp::connection_ptr& tcp_conn);
 };
 
 }   // end namespace plugins

--- a/services/LogService.cpp
+++ b/services/LogService.cpp
@@ -151,7 +151,7 @@ LogService::~LogService()
 }
 
 /// handles requests for LogService
-void LogService::operator()(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+void LogService::operator()(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     // Set Content-type to "text/plain" (plain ascii text)
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,

--- a/services/LogService.hpp
+++ b/services/LogService.hpp
@@ -57,7 +57,7 @@ public:
     void addLogString(const std::string& log_string);
 
     /// writes the events cached in memory to a response stream
-    void writeLogEvents(pion::http::response_writer_ptr& writer);
+    void writeLogEvents(const pion::http::response_writer_ptr& writer);
 
 private:
     /// default maximum number of events cached in memory
@@ -127,8 +127,8 @@ public:
     virtual ~LogService();
     
     /// handles a new HTTP request
-    virtual void operator()(pion::http::request_ptr& http_request_ptr,
-                            pion::tcp::connection_ptr& tcp_conn);
+    virtual void operator()(const pion::http::request_ptr& http_request_ptr,
+                            const pion::tcp::connection_ptr& tcp_conn);
 
     /// returns the log appender used by LogService
     inline LogServiceAppender& getLogAppender(void) {

--- a/src/http_basic_auth.cpp
+++ b/src/http_basic_auth.cpp
@@ -32,7 +32,7 @@ basic_auth::basic_auth(user_manager_ptr userManager, const std::string& realm)
     set_logger(PION_GET_LOGGER("pion.http.basic_auth"));
 }
     
-bool basic_auth::handle_request(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+bool basic_auth::handle_request(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     if (!need_authentication(http_request_ptr)) {
         return true; // this request does not require authentication
@@ -130,8 +130,8 @@ bool basic_auth::parse_credentials(const std::string &credentials,
     return true;
 }
     
-void basic_auth::handle_unauthorized(http::request_ptr& http_request_ptr,
-    tcp::connection_ptr& tcp_conn)
+void basic_auth::handle_unauthorized(const http::request_ptr& http_request_ptr,
+    const tcp::connection_ptr& tcp_conn)
 {
     // authentication failed, send 401.....
     static const std::string CONTENT =

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -50,7 +50,7 @@ cookie_auth::cookie_auth(user_manager_ptr userManager,
         m_random_die();
 }
     
-bool cookie_auth::handle_request(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+bool cookie_auth::handle_request(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     if (process_login(http_request_ptr,tcp_conn)) {
         return false; // we processed login/logout request, no future processing for this request permitted
@@ -102,7 +102,7 @@ void cookie_auth::set_option(const std::string& name, const std::string& value)
         BOOST_THROW_EXCEPTION( error::bad_arg() << error::errinfo_arg_name(name) );
 }
 
-bool cookie_auth::process_login(http::request_ptr& http_request_ptr, tcp::connection_ptr& tcp_conn)
+bool cookie_auth::process_login(const http::request_ptr& http_request_ptr, const tcp::connection_ptr& tcp_conn)
 {
     // strip off trailing slash if the request has one
     std::string resource(http::server::strip_trailing_slash(http_request_ptr->get_resource()));
@@ -168,8 +168,8 @@ bool cookie_auth::process_login(http::request_ptr& http_request_ptr, tcp::connec
     return true;
 }
 
-void cookie_auth::handle_unauthorized(http::request_ptr& http_request_ptr,
-    tcp::connection_ptr& tcp_conn)
+void cookie_auth::handle_unauthorized(const http::request_ptr& http_request_ptr,
+    const tcp::connection_ptr& tcp_conn)
 {
     // if redirection option is used, send redirect
     if (!m_redirect.empty()) {
@@ -196,8 +196,8 @@ void cookie_auth::handle_unauthorized(http::request_ptr& http_request_ptr,
     writer->send();
 }
 
-void cookie_auth::handle_redirection(http::request_ptr& http_request_ptr,
-                                        tcp::connection_ptr& tcp_conn,
+void cookie_auth::handle_redirection(const http::request_ptr& http_request_ptr,
+                                        const tcp::connection_ptr& tcp_conn,
                                         const std::string &redirection_url,
                                         const std::string &new_cookie,
                                         bool delete_cookie
@@ -234,8 +234,8 @@ void cookie_auth::handle_redirection(http::request_ptr& http_request_ptr,
     writer->send();
 }
 
-void cookie_auth::handle_ok(http::request_ptr& http_request_ptr,
-                              tcp::connection_ptr& tcp_conn,
+void cookie_auth::handle_ok(const http::request_ptr& http_request_ptr,
+                              const tcp::connection_ptr& tcp_conn,
                               const std::string &new_cookie,
                               bool delete_cookie
                               )

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -26,7 +26,7 @@ const unsigned int          server::MAX_REDIRECTS = 10;
 
 // server member functions
 
-void server::handle_connection(tcp::connection_ptr& tcp_conn)
+void server::handle_connection(const tcp::connection_ptr& tcp_conn)
 {
     request_reader_ptr my_reader_ptr;
     my_reader_ptr = request_reader::create(tcp_conn, boost::bind(&server::handle_request,
@@ -35,8 +35,8 @@ void server::handle_connection(tcp::connection_ptr& tcp_conn)
     my_reader_ptr->receive();
 }
 
-void server::handle_request(http::request_ptr& http_request_ptr,
-    tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec)
+void server::handle_request(const http::request_ptr& http_request_ptr,
+    const tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec)
 {
     if (ec || ! http_request_ptr->is_valid()) {
         tcp_conn->set_lifecycle(tcp::connection::LIFECYCLE_CLOSE); // make sure it will get closed
@@ -184,8 +184,8 @@ void server::add_redirect(const std::string& requested_resource,
     PION_LOG_INFO(m_logger, "Added redirection for HTTP resource " << clean_requested_resource << " to resource " << clean_new_resource);
 }
 
-void server::handle_bad_request(http::request_ptr& http_request_ptr,
-                                  tcp::connection_ptr& tcp_conn)
+void server::handle_bad_request(const http::request_ptr& http_request_ptr,
+                                  const tcp::connection_ptr& tcp_conn)
 {
     static const std::string BAD_REQUEST_HTML =
         "<html><head>\n"
@@ -202,8 +202,8 @@ void server::handle_bad_request(http::request_ptr& http_request_ptr,
     writer->send();
 }
 
-void server::handle_not_found_request(http::request_ptr& http_request_ptr,
-                                       tcp::connection_ptr& tcp_conn)
+void server::handle_not_found_request(const http::request_ptr& http_request_ptr,
+                                       const tcp::connection_ptr& tcp_conn)
 {
     static const std::string NOT_FOUND_HTML_START =
         "<html><head>\n"
@@ -224,8 +224,8 @@ void server::handle_not_found_request(http::request_ptr& http_request_ptr,
     writer->send();
 }
 
-void server::handle_server_error(http::request_ptr& http_request_ptr,
-                                   tcp::connection_ptr& tcp_conn,
+void server::handle_server_error(const http::request_ptr& http_request_ptr,
+                                   const tcp::connection_ptr& tcp_conn,
                                    const std::string& error_msg)
 {
     static const std::string SERVER_ERROR_HTML_START =
@@ -247,8 +247,8 @@ void server::handle_server_error(http::request_ptr& http_request_ptr,
     writer->send();
 }
 
-void server::handle_forbidden_request(http::request_ptr& http_request_ptr,
-                                        tcp::connection_ptr& tcp_conn,
+void server::handle_forbidden_request(const http::request_ptr& http_request_ptr,
+                                        const tcp::connection_ptr& tcp_conn,
                                         const std::string& error_msg)
 {
     static const std::string FORBIDDEN_HTML_START =
@@ -274,8 +274,8 @@ void server::handle_forbidden_request(http::request_ptr& http_request_ptr,
     writer->send();
 }
 
-void server::handle_method_not_allowed(http::request_ptr& http_request_ptr,
-                                        tcp::connection_ptr& tcp_conn,
+void server::handle_method_not_allowed(const http::request_ptr& http_request_ptr,
+                                        const tcp::connection_ptr& tcp_conn,
                                         const std::string& allowed_methods)
 {
     static const std::string NOT_ALLOWED_HTML_START =

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -56,7 +56,7 @@ parser::parser()
 
 boost::tribool parser::parse(http_protocol_info& http_info,
                              boost::system::error_code& ec,
-                             decompressor_ptr& decompressor,
+                             const decompressor_ptr& decompressor,
                              const char *packet_ptr,
                              boost::uint32_t& length_packet,
                              boost::uint32_t current_stream_count)
@@ -140,7 +140,7 @@ boost::uint32_t parser::get_control_frame_stream_id(const char *ptr)
 }
     
 boost::tribool parser::parse_spdy_frame(boost::system::error_code& ec,
-                                        decompressor_ptr& decompressor,
+                                        const decompressor_ptr& decompressor,
                                         http_protocol_info& http_info,
                                         boost::uint32_t& length_packet,
                                         boost::uint32_t current_stream_count)
@@ -346,7 +346,7 @@ bool parser::populate_frame(boost::system::error_code& ec,
 }
 
 void parser::parse_header_payload(boost::system::error_code &ec,
-                                  decompressor_ptr& decompressor,
+                                  const decompressor_ptr& decompressor,
                                   const spdy_control_frame_info& frame,
                                   http_protocol_info& http_info,
                                   boost::uint32_t current_stream_count)

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -196,7 +196,7 @@ void server::listen(void)
     }
 }
 
-void server::handle_accept(tcp::connection_ptr& tcp_conn,
+void server::handle_accept(const tcp::connection_ptr& tcp_conn,
                              const boost::system::error_code& accept_error)
 {
     if (accept_error) {
@@ -229,7 +229,7 @@ void server::handle_accept(tcp::connection_ptr& tcp_conn,
     }
 }
 
-void server::handle_ssl_handshake(tcp::connection_ptr& tcp_conn,
+void server::handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
                                    const boost::system::error_code& handshake_error)
 {
     if (handshake_error) {
@@ -244,7 +244,7 @@ void server::handle_ssl_handshake(tcp::connection_ptr& tcp_conn,
     }
 }
 
-void server::finish_connection(tcp::connection_ptr& tcp_conn)
+void server::finish_connection(const tcp::connection_ptr& tcp_conn)
 {
     boost::mutex::scoped_lock server_lock(m_mutex);
     if (m_is_listening && tcp_conn->get_keep_alive()) {

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -17,7 +17,7 @@ namespace tcp {     // begin namespace tcp
 
 // timer member functions
 
-timer::timer(tcp::connection_ptr& conn_ptr)
+timer::timer(const tcp::connection_ptr& conn_ptr)
     : m_conn_ptr(conn_ptr), m_timer(conn_ptr->get_io_service()),
     m_timer_active(false), m_was_cancelled(false)
 {

--- a/tests/http_plugin_server_tests.cpp
+++ b/tests/http_plugin_server_tests.cpp
@@ -67,7 +67,7 @@ public:
      * @param resource
      */
     static inline boost::shared_ptr<ChunkedPostRequestSender>
-        create(pion::tcp::connection_ptr& tcp_conn, const std::string& resource) 
+        create(const pion::tcp::connection_ptr& tcp_conn, const std::string& resource)
     {
         return boost::shared_ptr<ChunkedPostRequestSender>(new ChunkedPostRequestSender(tcp_conn, resource));
     }
@@ -89,7 +89,7 @@ public:
 
 protected:
 
-    ChunkedPostRequestSender(pion::tcp::connection_ptr& tcp_conn,
+    ChunkedPostRequestSender(const pion::tcp::connection_ptr& tcp_conn,
                              const std::string& resource);
     
     /**
@@ -117,7 +117,7 @@ private:
     pion::http::request_writer_ptr         m_writer;
 };
 
-ChunkedPostRequestSender::ChunkedPostRequestSender(pion::tcp::connection_ptr& tcp_conn,
+ChunkedPostRequestSender::ChunkedPostRequestSender(const pion::tcp::connection_ptr& tcp_conn,
                                                    const std::string& resource)
     : m_logger(PION_GET_LOGGER("pion.ChunkedPostRequestSender")),
     m_writer(pion::http::request_writer::create(tcp_conn))
@@ -1075,8 +1075,8 @@ public:
      * @param http_request_ptr the HTTP request to respond to
      * @param tcp_conn the TCP connection to send the response over
      */
-    void sendResponseWithContentButNoLength(http::request_ptr& http_request_ptr,
-                                            tcp::connection_ptr& tcp_conn)
+    void sendResponseWithContentButNoLength(const http::request_ptr& http_request_ptr,
+                                            const tcp::connection_ptr& tcp_conn)
     {
         // make sure it will get closed when finished
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE);
@@ -1099,7 +1099,7 @@ public:
     }
     
     /// reads in a HTTP response asynchronously
-    void readAsyncResponse(tcp::connection_ptr& tcp_conn)
+    void readAsyncResponse(const tcp::connection_ptr& tcp_conn)
     {
         http::request http_request("GET");
 		http::response_reader_ptr my_reader_ptr(http::response_reader::create(tcp_conn, http_request,
@@ -1118,7 +1118,7 @@ public:
     }
     
     /// checks the validity of the HTTP response
-    void checkResponse(http::response_ptr& http_response_ptr,
+    void checkResponse(const http::response_ptr& http_response_ptr,
         tcp::connection_ptr& conn_ptr, const boost::system::error_code& ec)
     {
         checkResponse(*http_response_ptr);

--- a/tests/tcp_server_tests.cpp
+++ b/tests/tcp_server_tests.cpp
@@ -43,7 +43,7 @@ public:
      * 
      * @param tcp_conn the new TCP connection to handle
      */
-    virtual void handle_connection(pion::tcp::connection_ptr& tcp_conn) {
+    virtual void handle_connection(const pion::tcp::connection_ptr& tcp_conn) {
         static const std::string HELLO_MESSAGE("Hello there!\n");
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE);  // make sure it will get closed
         tcp_conn->async_write(boost::asio::buffer(HELLO_MESSAGE),
@@ -60,7 +60,7 @@ private:
      * @param tcp_conn the TCP connection to the server
      * @param write_error message that explains what went wrong (if anything)
      */
-    void handle_write(pion::tcp::connection_ptr& tcp_conn,
+    void handle_write(const pion::tcp::connection_ptr& tcp_conn,
                      const boost::system::error_code& write_error)
     {
         if (write_error) {
@@ -79,7 +79,7 @@ private:
      * @param read_error message that explains what went wrong (if anything)
      * @param bytes_read number of bytes read from the client
      */
-    void handleRead(pion::tcp::connection_ptr& tcp_conn,
+    void handleRead(const pion::tcp::connection_ptr& tcp_conn,
                     const boost::system::error_code& read_error,
                     std::size_t bytes_read)
     {
@@ -253,7 +253,7 @@ public:
      * 
      * @param tcp_conn the new TCP connection to handle
      */
-    virtual void handle_connection(pion::tcp::connection_ptr& tcp_conn) {
+    virtual void handle_connection(const pion::tcp::connection_ptr& tcp_conn) {
         // wait until an HTTP request is received or an error occurs
         boost::system::error_code error_code;
         http::request http_request;

--- a/utils/helloserver.cpp
+++ b/utils/helloserver.cpp
@@ -23,7 +23,7 @@ class HelloServer : public tcp::server {
 public:
     HelloServer(const unsigned int tcp_port) : tcp::server(tcp_port) {}
     virtual ~HelloServer() {}
-    virtual void handle_connection(tcp::connection_ptr& tcp_conn)
+    virtual void handle_connection(const tcp::connection_ptr& tcp_conn)
     {
         static const std::string HELLO_MESSAGE("Hello there!\x0D\x0A");
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE); // make sure it will get closed


### PR DESCRIPTION
Functions that take a boost::shared_ptr typedef do not manipulate the smart pointer itself. This commit makes all smart pointer typedef arguments const-ref.
Discussion here:
https://github.com/splunk/pion/pull/64