### PR TITLE
PoC: Support for standalone ASIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ option(USE_LOG4CXX "Use log4cxx" OFF)
 option(USE_LOG4CPP "Use log4cpp" OFF)
 option(DISABLE_LOGGING "Disable logging" ON)
 
+# ASIO
+option(USE_STANDALONE_ASIO "Use ASIO in standalone mode" OFF)
+
 #----------------------------------------------------------
 
 # cleanup prefix lib for Unix-like OSes
@@ -136,6 +139,11 @@ endif()
 
 if (DISABLE_LOGGING)
     set(PION_DISABLE_LOGGING 1)
+endif()
+
+if (USE_STANDALONE_ASIO)
+    set(PION_HAVE_CXX11 1)
+    set(PION_HAVE_STANDALONE_ASIO 1)
 endif()
 
 find_package(Doxygen)

--- a/cmake/config.hpp.cmake
+++ b/cmake/config.hpp.cmake
@@ -60,6 +60,12 @@
    or uncomment the following line. */
 #cmakedefine PION_DISABLE_LOGGING ${PION_DISABLE_LOGGING}
 
+/* Define to 1 to use C++11 types rather than boost types */
+#cmakedefine PION_HAVE_CXX11 ${PION_HAVE_CXX11}
+
+/* Define to 1 to use the standalone ASIO library */
+#cmakedefine PION_HAVE_STANDALONE_ASIO ${PION_HAVE_STANDALONE_ASIO}
+
 // -----------------------------------------------------------------------
 
 /* Define to 1 if you have the `zlib' library. */

--- a/include/pion/admin_rights.hpp
+++ b/include/pion/admin_rights.hpp
@@ -12,7 +12,7 @@
 
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
-#include <boost/cstdint.hpp>
+#include <pion/stdx/cstdint.hpp>
 #include <boost/thread/mutex.hpp>
 
 
@@ -54,13 +54,13 @@ private:
      * @param name descriptive name to lookup (user or group name, may be id)
      * @param file system credentials file to look within
      *
-     * @return boost::int32_t identifier found, or -1 if none found
+     * @return stdx::int32_t identifier found, or -1 if none found
      */
     static long find_system_id(const std::string& name, const std::string& file);
 
 
     /// adminisitrator or root user identifier
-    static const boost::int16_t         ADMIN_USER_ID;
+    static const stdx::int16_t         ADMIN_USER_ID;
 
     /// mutex used to prevent multiple threads from corrupting user id
     static boost::mutex                 m_mutex;
@@ -72,7 +72,7 @@ private:
     boost::unique_lock<boost::mutex>    m_lock;
 
     /// saved user identifier before upgrading to administrator
-    boost::int16_t                      m_user_id;
+    stdx::int16_t                      m_user_id;
 
     /// true if the class currently holds administrative rights
     bool                                m_has_rights;

--- a/include/pion/admin_rights.hpp
+++ b/include/pion/admin_rights.hpp
@@ -13,8 +13,7 @@
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/stdx/cstdint.hpp>
-#include <boost/thread/mutex.hpp>
-
+#include <pion/stdx/mutex.hpp>
 
 namespace pion {    // begin namespace pion
 
@@ -63,13 +62,13 @@ private:
     static const stdx::int16_t         ADMIN_USER_ID;
 
     /// mutex used to prevent multiple threads from corrupting user id
-    static boost::mutex                 m_mutex;
+    static stdx::mutex                 m_mutex;
 
     /// primary logging interface used by this class        
     logger                              m_logger;
 
     /// lock used to prevent multiple threads from corrupting user id
-    boost::unique_lock<boost::mutex>    m_lock;
+    stdx::unique_lock<stdx::mutex>    m_lock;
 
     /// saved user identifier before upgrading to administrator
     stdx::int16_t                      m_user_id;

--- a/include/pion/algorithm.hpp
+++ b/include/pion/algorithm.hpp
@@ -11,7 +11,7 @@
 #define __PION_ALGORITHM_HEADER__
 
 #include <string>
-#include <boost/cstdint.hpp>
+#include <pion/stdx/cstdint.hpp>
 #include <pion/config.hpp>
 
 namespace pion {    // begin namespace pion
@@ -58,82 +58,82 @@ struct PION_API algorithm {
     static void float_to_bytes(long double value, unsigned char *ptr, size_t num_exp_bits, size_t num_fraction_bits);
 
     /// convert sequence of one byte to 8-bit unsigned integer
-    static inline boost::uint8_t to_uint8(unsigned char byte) {
-        return boost::uint8_t(byte);
+    static inline stdx::uint8_t to_uint8(unsigned char byte) {
+        return stdx::uint8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit signed integer
-    static inline boost::int8_t to_int8(unsigned char byte) {
-        return boost::int8_t(byte);
+    static inline stdx::int8_t to_int8(unsigned char byte) {
+        return stdx::int8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit unsigned integer
-    static inline boost::uint8_t to_uint8(char byte) {
-        return boost::uint8_t(byte);
+    static inline stdx::uint8_t to_uint8(char byte) {
+        return stdx::uint8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit signed integer
-    static inline boost::int8_t to_int8(char byte) {
-        return boost::int8_t(byte);
+    static inline stdx::int8_t to_int8(char byte) {
+        return stdx::int8_t(byte);
     }
     
     /// convert sequence of two bytes to 16-bit unsigned integer
-    static inline boost::uint16_t to_uint16(unsigned char high, unsigned char low) {
-        return (((boost::uint16_t)high) << 8) | ((boost::uint16_t)low);
+    static inline stdx::uint16_t to_uint16(unsigned char high, unsigned char low) {
+        return (((stdx::uint16_t)high) << 8) | ((stdx::uint16_t)low);
     }
 
     /// convert sequence of two bytes to 16-bit signed integer
-    static inline boost::int16_t to_int16(unsigned char high, unsigned char low) {
-        return (((boost::int16_t)high) << 8) | ((boost::int16_t)low);
+    static inline stdx::int16_t to_int16(unsigned char high, unsigned char low) {
+        return (((stdx::int16_t)high) << 8) | ((stdx::int16_t)low);
     }
 
     /// convert sequence of three bytes to 24-bit unsigned integer
-    static inline boost::uint32_t to_uint24(unsigned char high, unsigned char mid, unsigned char low) {
-        return (((boost::uint32_t)high) << 16) | (((boost::uint32_t)mid) << 8) | ((boost::uint32_t)low);
+    static inline stdx::uint32_t to_uint24(unsigned char high, unsigned char mid, unsigned char low) {
+        return (((stdx::uint32_t)high) << 16) | (((stdx::uint32_t)mid) << 8) | ((stdx::uint32_t)low);
     }
     
     /// convert sequence of three bytes to 24-bit signed integer
-    static inline boost::int32_t to_int24(unsigned char high, unsigned char mid, unsigned char low) {
-        return (((boost::int32_t)high) << 16) | (((boost::int32_t)mid) << 8) | ((boost::int32_t)low);
+    static inline stdx::int32_t to_int24(unsigned char high, unsigned char mid, unsigned char low) {
+        return (((stdx::int32_t)high) << 16) | (((stdx::int32_t)mid) << 8) | ((stdx::int32_t)low);
     }
     
     /// convert sequence of four bytes to 32-bit unsigned integer
-    static inline boost::uint32_t to_uint32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
-        return (((boost::uint32_t)high) << 24) | (((boost::uint32_t)mid1) << 16) | (((boost::uint32_t)mid2) << 8) | ((boost::uint32_t)low);
+    static inline stdx::uint32_t to_uint32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
+        return (((stdx::uint32_t)high) << 24) | (((stdx::uint32_t)mid1) << 16) | (((stdx::uint32_t)mid2) << 8) | ((stdx::uint32_t)low);
     }
     
     /// convert sequence of four bytes to 32-bit signed integer
-    static inline boost::int32_t to_int32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
-        return (((boost::int32_t)high) << 24) | (((boost::int32_t)mid1) << 16) | (((boost::int32_t)mid2) << 8) | ((boost::int32_t)low);
+    static inline stdx::int32_t to_int32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
+        return (((stdx::int32_t)high) << 24) | (((stdx::int32_t)mid1) << 16) | (((stdx::int32_t)mid2) << 8) | ((stdx::int32_t)low);
     }
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
-    static inline boost::uint64_t to_uint64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
-        return (((boost::uint64_t)high) << 56) | (((boost::uint64_t)mid1) << 48) | (((boost::uint64_t)mid2) << 40) | (((boost::uint64_t)mid3) << 32)
-            | (((boost::uint64_t)mid4) << 24) | (((boost::uint64_t)mid5) << 16) | (((boost::uint64_t)mid6) << 8) | ((boost::uint64_t)low);
+    static inline stdx::uint64_t to_uint64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
+        return (((stdx::uint64_t)high) << 56) | (((stdx::uint64_t)mid1) << 48) | (((stdx::uint64_t)mid2) << 40) | (((stdx::uint64_t)mid3) << 32)
+            | (((stdx::uint64_t)mid4) << 24) | (((stdx::uint64_t)mid5) << 16) | (((stdx::uint64_t)mid6) << 8) | ((stdx::uint64_t)low);
     }
     
     /// convert sequence of eight bytes to 64-bit signed integer
-    static inline boost::int64_t to_int64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
-        return (((boost::int64_t)high) << 56) | (((boost::int64_t)mid1) << 48) | (((boost::int64_t)mid2) << 40) | (((boost::int64_t)mid3) << 32)
-        | (((boost::int64_t)mid4) << 24) | (((boost::int64_t)mid5) << 16) | (((boost::int64_t)mid6) << 8) | ((boost::int64_t)low);
+    static inline stdx::int64_t to_int64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
+        return (((stdx::int64_t)high) << 56) | (((stdx::int64_t)mid1) << 48) | (((stdx::int64_t)mid2) << 40) | (((stdx::int64_t)mid3) << 32)
+        | (((stdx::int64_t)mid4) << 24) | (((stdx::int64_t)mid5) << 16) | (((stdx::int64_t)mid6) << 8) | ((stdx::int64_t)low);
     }
 
     /// convert sequence of two bytes to 16-bit unsigned integer
     template <typename T1, typename T2>
-    static inline boost::uint16_t to_uint16(T1 high, T2 low) {
+    static inline stdx::uint16_t to_uint16(T1 high, T2 low) {
         return to_uint16(static_cast<unsigned char>(high), static_cast<unsigned char>(low));
     }
     
     /// convert sequence of two bytes to 16-bit signed integer
     template <typename T1, typename T2>
-    static inline boost::int16_t to_int16(T1 high, T2 low) {
+    static inline stdx::int16_t to_int16(T1 high, T2 low) {
         return to_int16(static_cast<unsigned char>(high), static_cast<unsigned char>(low));
     }
     
     /// convert sequence of three bytes to 24-bit unsigned integer
     template <typename T1, typename T2, typename T3>
-    static inline boost::uint32_t to_uint24(T1 high, T2 mid, T3 low) {
+    static inline stdx::uint32_t to_uint24(T1 high, T2 mid, T3 low) {
         return to_uint24(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid),
                          static_cast<unsigned char>(low));
@@ -141,7 +141,7 @@ struct PION_API algorithm {
     
     /// convert sequence of three bytes to 24-bit signed integer
     template <typename T1, typename T2, typename T3>
-    static inline boost::int32_t to_int24(T1 high, T2 mid, T3 low) {
+    static inline stdx::int32_t to_int24(T1 high, T2 mid, T3 low) {
         return to_int24(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid),
                         static_cast<unsigned char>(low));
@@ -149,7 +149,7 @@ struct PION_API algorithm {
     
     /// convert sequence of four bytes to 32-bit unsigned integer
     template <typename T1, typename T2, typename T3, typename T4>
-    static inline boost::uint32_t to_uint32(T1 high, T2 mid1, T3 mid2, T4 low) {
+    static inline stdx::uint32_t to_uint32(T1 high, T2 mid1, T3 mid2, T4 low) {
         return to_uint32(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid1),
                          static_cast<unsigned char>(mid2),
@@ -158,7 +158,7 @@ struct PION_API algorithm {
     
     /// convert sequence of four bytes to 32-bit signed integer
     template <typename T1, typename T2, typename T3, typename T4>
-    static inline boost::int32_t to_int32(T1 high, T2 mid1, T3 mid2, T4 low) {
+    static inline stdx::int32_t to_int32(T1 high, T2 mid1, T3 mid2, T4 low) {
         return to_int32(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid1),
                         static_cast<unsigned char>(mid2),
@@ -167,7 +167,7 @@ struct PION_API algorithm {
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    static inline boost::uint64_t to_uint64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
+    static inline stdx::uint64_t to_uint64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
         return to_uint64(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid1),
                          static_cast<unsigned char>(mid2),
@@ -180,7 +180,7 @@ struct PION_API algorithm {
     
     /// convert sequence of eight bytes to 64-bit signed integer
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    static inline boost::int64_t to_int64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
+    static inline stdx::int64_t to_int64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
         return to_int64(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid1),
                         static_cast<unsigned char>(mid2),
@@ -194,93 +194,93 @@ struct PION_API algorithm {
     
     /// convert byte pointer into an 8-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint8_t to_uint8(const Byte *buf) {
+    static inline stdx::uint8_t to_uint8(const Byte *buf) {
         return to_uint8(buf[0]);
     }
     
     /// convert byte pointer into an 8-bit signed integer
     template <typename Byte>
-    static inline boost::int8_t to_int8(const Byte *buf) {
+    static inline stdx::int8_t to_int8(const Byte *buf) {
         return to_int8(buf[0]);
     }
     
     /// convert sequence of two bytes to 16-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint16_t to_uint16(const Byte *buf) {
+    static inline stdx::uint16_t to_uint16(const Byte *buf) {
         return to_uint16(buf[0], buf[1]);
     }
     
     /// convert sequence of two bytes to 16-bit signed integer
     template <typename Byte>
-    static inline boost::int16_t to_int16(const Byte *buf) {
+    static inline stdx::int16_t to_int16(const Byte *buf) {
         return to_int16(buf[0], buf[1]);
     }
     
     /// convert sequence of three bytes to 24-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint32_t to_uint24(const Byte *buf) {
+    static inline stdx::uint32_t to_uint24(const Byte *buf) {
         return to_uint24(buf[0], buf[1], buf[2]);
     }
     
     /// convert sequence of three bytes to 24-bit signed integer
     template <typename Byte>
-    static inline boost::int32_t to_int24(const Byte *buf) {
+    static inline stdx::int32_t to_int24(const Byte *buf) {
         return to_int24(buf[0], buf[1], buf[2]);
     }
     
     /// convert sequence of four bytes to 32-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint32_t to_uint32(const Byte *buf) {
+    static inline stdx::uint32_t to_uint32(const Byte *buf) {
         return to_uint32(buf[0], buf[1], buf[2], buf[3]);
     }
     
     /// convert sequence of four bytes to 32-bit signed integer
     template <typename Byte>
-    static inline boost::int32_t to_int32(const Byte *buf) {
+    static inline stdx::int32_t to_int32(const Byte *buf) {
         return to_int32(buf[0], buf[1], buf[2], buf[3]);
     }
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint64_t to_uint64(const Byte *buf) {
+    static inline stdx::uint64_t to_uint64(const Byte *buf) {
         return to_uint64(buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     }
     
     /// convert sequence of eight bytes to 64-bit signed integer
     template <typename Byte>
-    static inline boost::int64_t to_int64(const Byte *buf) {
+    static inline stdx::int64_t to_int64(const Byte *buf) {
         return to_int64(buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     }
 
     /// convert 8-bit unsigned integer into sequence of one byte
     template <typename Byte>
-    static inline void from_uint8(Byte *buf, const boost::uint8_t n) {
+    static inline void from_uint8(Byte *buf, const stdx::uint8_t n) {
         buf[0] = n & 0xFF;
     }
     
     /// convert 8-bit signed integer into sequence of one byte
     template <typename Byte>
-    static inline void from_int8(Byte *buf, const boost::int8_t n) {
+    static inline void from_int8(Byte *buf, const stdx::int8_t n) {
         buf[0] = n & 0xFF;
     }
     
     /// convert 16-bit unsigned integer into sequence of two bytes
     template <typename Byte>
-    static inline void from_uint16(Byte *buf, const boost::uint16_t n) {
+    static inline void from_uint16(Byte *buf, const stdx::uint16_t n) {
         buf[0] = (n >> 8) & 0xFF;
         buf[1] = n & 0xFF;
     }
 
     /// convert 16-bit signed integer into sequence of two bytes
     template <typename Byte>
-    static inline void from_int16(Byte *buf, const boost::int16_t n) {
+    static inline void from_int16(Byte *buf, const stdx::int16_t n) {
         buf[0] = (n >> 8) & 0xFF;
         buf[1] = n & 0xFF;
     }
     
     /// convert 24-bit unsigned integer into sequence of three bytes
     template <typename Byte>
-    static inline void from_uint24(Byte *buf, const boost::uint32_t n) {
+    static inline void from_uint24(Byte *buf, const stdx::uint32_t n) {
         buf[0] = (n >> 16) & 0xFF;
         buf[1] = (n >> 8) & 0xFF;
         buf[2] = n & 0xFF;
@@ -288,7 +288,7 @@ struct PION_API algorithm {
     
     /// convert 24-bit signed integer into sequence of three bytes
     template <typename Byte>
-    static inline void from_int24(Byte *buf, const boost::int32_t n) {
+    static inline void from_int24(Byte *buf, const stdx::int32_t n) {
         buf[0] = (n >> 16) & 0xFF;
         buf[1] = (n >> 8) & 0xFF;
         buf[2] = n & 0xFF;
@@ -296,7 +296,7 @@ struct PION_API algorithm {
     
     /// convert 32-bit unsigned integer into sequence of four bytes
     template <typename Byte>
-    static inline void from_uint32(Byte *buf, const boost::uint32_t n) {
+    static inline void from_uint32(Byte *buf, const stdx::uint32_t n) {
         buf[0] = (n >> 24) & 0xFF;
         buf[1] = (n >> 16) & 0xFF;
         buf[2] = (n >> 8) & 0xFF;
@@ -305,7 +305,7 @@ struct PION_API algorithm {
     
     /// convert 32-bit signed integer into sequence of four bytes
     template <typename Byte>
-    static inline void from_int32(Byte *buf, const boost::int32_t n) {
+    static inline void from_int32(Byte *buf, const stdx::int32_t n) {
         buf[0] = (n >> 24) & 0xFF;
         buf[1] = (n >> 16) & 0xFF;
         buf[2] = (n >> 8) & 0xFF;
@@ -314,7 +314,7 @@ struct PION_API algorithm {
 
     /// convert 64-bit unsigned integer into sequence of eight bytes
     template <typename Byte>
-    static inline void from_uint64(Byte *buf, const boost::uint64_t n) {
+    static inline void from_uint64(Byte *buf, const stdx::uint64_t n) {
         buf[0] = (n >> 56) & 0xFF;
         buf[1] = (n >> 48) & 0xFF;
         buf[2] = (n >> 40) & 0xFF;
@@ -327,7 +327,7 @@ struct PION_API algorithm {
     
     /// convert 64-bit signed integer into sequence of eight bytes
     template <typename Byte>
-    static inline void from_int64(Byte *buf, const boost::int64_t n) {
+    static inline void from_int64(Byte *buf, const stdx::int64_t n) {
         buf[0] = (n >> 56) & 0xFF;
         buf[1] = (n >> 48) & 0xFF;
         buf[2] = (n >> 40) & 0xFF;

--- a/include/pion/http/auth.hpp
+++ b/include/pion/http/auth.hpp
@@ -13,7 +13,6 @@
 #include <set>
 #include <map>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/logger.hpp>
@@ -21,6 +20,7 @@
 #include <pion/tcp/connection.hpp>
 #include <pion/user.hpp>
 #include <pion/http/request.hpp>
+#include <pion/stdx/memory.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>    // order important, otherwise compiling error under win32
 
 
@@ -166,7 +166,7 @@ protected:
 };
 
 /// data type for a auth pointer
-typedef boost::shared_ptr<auth> auth_ptr;
+typedef stdx::shared_ptr<auth> auth_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/auth.hpp
+++ b/include/pion/http/auth.hpp
@@ -162,7 +162,7 @@ protected:
     resource_set_type       m_white_list;
 
     /// mutex used to protect access to the resources
-    mutable boost::mutex    m_resource_mutex;
+    mutable stdx::mutex    m_resource_mutex;
 };
 
 /// data type for a auth pointer

--- a/include/pion/http/basic_auth.hpp
+++ b/include/pion/http/basic_auth.hpp
@@ -98,7 +98,7 @@ private:
     user_cache_type             m_user_cache;
     
     /// mutex used to protect access to the user cache
-    mutable boost::mutex        m_cache_mutex;
+    mutable stdx::mutex        m_cache_mutex;
 };
 
     

--- a/include/pion/http/cookie_auth.hpp
+++ b/include/pion/http/cookie_auth.hpp
@@ -166,7 +166,7 @@ private:
     user_cache_type             m_user_cache;
     
     /// mutex used to protect access to the user cache
-    mutable boost::mutex        m_cache_mutex;
+    mutable stdx::mutex        m_cache_mutex;
 };
 
     

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -13,13 +13,13 @@
 #include <iosfwd>
 #include <vector>
 #include <cstring>
-#include <boost/cstdint.hpp>
 #include <boost/asio.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/regex.hpp>
 #include <pion/config.hpp>
+#include <pion/stdx/cstdint.hpp>
 #include <pion/http/types.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
@@ -176,10 +176,10 @@ public:
     }
 
     /// returns the major HTTP version number
-    inline boost::uint16_t get_version_major(void) const { return m_version_major; }
+    inline stdx::uint16_t get_version_major(void) const { return m_version_major; }
 
     /// returns the minor HTTP version number
-    inline boost::uint16_t get_version_minor(void) const { return m_version_minor; }
+    inline stdx::uint16_t get_version_minor(void) const { return m_version_minor; }
 
     /// returns a string representation of the HTTP version (i.e. "HTTP/1.1")
     inline std::string get_version_string(void) const {
@@ -289,13 +289,13 @@ public:
     inline void set_remote_ip(const boost::asio::ip::address& ip) { m_remote_ip = ip; }
 
     /// sets the major HTTP version number
-    inline void set_version_major(const boost::uint16_t n) {
+    inline void set_version_major(const stdx::uint16_t n) {
         m_version_major = n;
         clear_first_line();
     }
 
     /// sets the minor HTTP version number
-    inline void set_version_minor(const boost::uint16_t n) {
+    inline void set_version_minor(const stdx::uint16_t n) {
         m_version_minor = n;
         clear_first_line();
     }
@@ -701,10 +701,10 @@ private:
     boost::asio::ip::address        m_remote_ip;
 
     /// HTTP major version number
-    boost::uint16_t                 m_version_major;
+    stdx::uint16_t                 m_version_major;
 
     /// HTTP major version number
-    boost::uint16_t                 m_version_minor;
+    stdx::uint16_t                 m_version_minor;
 
     /// the length of the payload content (in bytes)
     size_t                          m_content_length;

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -20,6 +20,7 @@
 #include <pion/config.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/cstdint.hpp>
+#include <pion/stdx/system_error.hpp>
 #include <pion/http/types.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
@@ -65,7 +66,7 @@ public:
 
     /// data type for library errors returned during receive() operations
     struct receive_error_t
-        : public boost::system::error_category
+        : public stdx::error_category
     {
         virtual ~receive_error_t() {}
         virtual inline const char *name() const BOOST_SYSTEM_NOEXCEPT { return "receive_error_t"; }
@@ -416,7 +417,7 @@ public:
      * @return std::size_t number of bytes written to the connection
      */
     std::size_t send(tcp::connection& tcp_conn,
-                     boost::system::error_code& ec,
+                     stdx::error_code& ec,
                      bool headers_only = false);
 
     /**
@@ -429,7 +430,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t receive(tcp::connection& tcp_conn,
-                        boost::system::error_code& ec,
+                        stdx::error_code& ec,
                         parser& http_parser);
     
     /**
@@ -443,7 +444,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t receive(tcp::connection& tcp_conn,
-                        boost::system::error_code& ec,
+                        stdx::error_code& ec,
                         bool headers_only = false,
                         std::size_t max_content_length = static_cast<size_t>(-1));
 
@@ -457,7 +458,7 @@ public:
      * @return std::size_t number of bytes written to the connection
      */
     std::size_t write(std::ostream& out,
-                      boost::system::error_code& ec,
+                      stdx::error_code& ec,
                       bool headers_only = false);
 
     /**
@@ -470,7 +471,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t read(std::istream& in,
-                     boost::system::error_code& ec,
+                     stdx::error_code& ec,
                      parser& http_parser);
     
     /**
@@ -484,7 +485,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t read(std::istream& in,
-                     boost::system::error_code& ec,
+                     stdx::error_code& ec,
                      bool headers_only = false,
                      std::size_t max_content_length = static_cast<size_t>(-1));
 

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -13,12 +13,12 @@
 #include <iosfwd>
 #include <vector>
 #include <cstring>
-#include <boost/asio.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/regex.hpp>
 #include <pion/config.hpp>
+#include <pion/stdx/asio.hpp>
 #include <pion/stdx/cstdint.hpp>
 #include <pion/http/types.hpp>
 
@@ -58,7 +58,7 @@ class PION_API message
 public:
 
     /// data type for I/O write buffers (these wrap existing data to be sent)
-    typedef std::vector<boost::asio::const_buffer>  write_buffers_t;
+    typedef std::vector<stdx::asio::const_buffer>  write_buffers_t;
 
     /// used to cache chunked data
     typedef std::vector<char>   chunk_cache_t;
@@ -149,7 +149,7 @@ public:
         clear_first_line();
         m_is_valid = m_is_chunked = m_chunks_supported
             = m_do_not_send_content_length = false;
-        m_remote_ip = boost::asio::ip::address_v4(0);
+        m_remote_ip = stdx::asio::ip::address_v4(0);
         m_version_major = m_version_minor = 1;
         m_content_length = 0;
         m_content_buf.clear();
@@ -171,7 +171,7 @@ public:
     inline bool get_chunks_supported(void) const { return m_chunks_supported; }
 
     /// returns IP address of the remote endpoint
-    inline boost::asio::ip::address& get_remote_ip(void) {
+    inline stdx::asio::ip::address& get_remote_ip(void) {
         return m_remote_ip;
     }
 
@@ -286,7 +286,7 @@ public:
     inline void set_chunks_supported(bool b) { m_chunks_supported = b; }
 
     /// sets IP address of the remote endpoint
-    inline void set_remote_ip(const boost::asio::ip::address& ip) { m_remote_ip = ip; }
+    inline void set_remote_ip(const stdx::asio::ip::address& ip) { m_remote_ip = ip; }
 
     /// sets the major HTTP version number
     inline void set_version_major(const stdx::uint16_t n) {
@@ -397,8 +397,8 @@ public:
         // update message headers
         prepare_headers_for_send(keep_alive, using_chunks);
         // add first message line
-        write_buffers.push_back(boost::asio::buffer(get_first_line()));
-        write_buffers.push_back(boost::asio::buffer(STRING_CRLF));
+        write_buffers.push_back(stdx::asio::buffer(get_first_line()));
+        write_buffers.push_back(stdx::asio::buffer(STRING_CRLF));
         // append cookie headers (if any)
         append_cookie_headers();
         // append HTTP headers
@@ -587,13 +587,13 @@ protected:
     inline void append_headers(write_buffers_t& write_buffers) {
         // add HTTP headers
         for (ihash_multimap::const_iterator i = m_headers.begin(); i != m_headers.end(); ++i) {
-            write_buffers.push_back(boost::asio::buffer(i->first));
-            write_buffers.push_back(boost::asio::buffer(HEADER_NAME_VALUE_DELIMITER));
-            write_buffers.push_back(boost::asio::buffer(i->second));
-            write_buffers.push_back(boost::asio::buffer(STRING_CRLF));
+            write_buffers.push_back(stdx::asio::buffer(i->first));
+            write_buffers.push_back(stdx::asio::buffer(HEADER_NAME_VALUE_DELIMITER));
+            write_buffers.push_back(stdx::asio::buffer(i->second));
+            write_buffers.push_back(stdx::asio::buffer(STRING_CRLF));
         }
         // add an extra CRLF to end HTTP headers
-        write_buffers.push_back(boost::asio::buffer(STRING_CRLF));
+        write_buffers.push_back(stdx::asio::buffer(STRING_CRLF));
     }
 
     /// appends HTTP headers for any cookies defined by the http::message
@@ -698,7 +698,7 @@ private:
     bool                            m_do_not_send_content_length;
 
     /// IP address of the remote endpoint
-    boost::asio::ip::address        m_remote_ip;
+    stdx::asio::ip::address        m_remote_ip;
 
     /// HTTP major version number
     stdx::uint16_t                 m_version_major;

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -13,12 +13,12 @@
 #include <string>
 #include <boost/noncopyable.hpp>
 #include <boost/logic/tribool.hpp>
-#include <boost/system/error_code.hpp>
 #include <boost/thread/once.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/http/message.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/system_error.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
     #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
@@ -72,7 +72,7 @@ public:
     
     /// class-specific error category
     class error_category_t
-        : public boost::system::error_category
+        : public stdx::error_category
     {
     public:
         const char *name() const BOOST_SYSTEM_NOEXCEPT { return "parser"; }
@@ -152,7 +152,7 @@ public:
      *                        true = finished parsing HTTP message,
      *                        indeterminate = not yet finished parsing HTTP message
      */
-    boost::tribool parse(http::message& http_msg, boost::system::error_code& ec);
+    boost::tribool parse(http::message& http_msg, stdx::error_code& ec);
 
     /**
      * attempts to continue parsing despite having missed data (length is known but content is not)
@@ -167,7 +167,7 @@ public:
      *                        indeterminate = not yet finished parsing HTTP message
      */
     boost::tribool parse_missing_data(http::message& http_msg, std::size_t len,
-        boost::system::error_code& ec);
+        stdx::error_code& ec);
 
     /**
      * finishes parsing an HTTP response message
@@ -228,7 +228,7 @@ public:
      * @param http_msg the HTTP message object being parsed
      */
     inline void skip_header_parsing(http::message& http_msg) {
-        boost::system::error_code ec;
+        stdx::error_code ec;
         finish_header_parsing(http_msg, ec);
     }
     
@@ -418,7 +418,7 @@ public:
      *                        indeterminate = payload content is available to be parsed
      */
     boost::tribool finish_header_parsing(http::message& http_msg,
-                                         boost::system::error_code& ec);
+                                         stdx::error_code& ec);
 
     /**
      * parses an X-Forwarded-For HTTP header, and extracts from it an IP
@@ -441,7 +441,7 @@ public:
 protected:
 
     /// Called after we have finished parsing the HTTP message headers
-    virtual void finished_parsing_headers(const boost::system::error_code& /* ec */) {}
+    virtual void finished_parsing_headers(const stdx::error_code& /* ec */) {}
     
     /**
      * parses an HTTP message up to the end of the headers using bytes 
@@ -455,7 +455,7 @@ protected:
      *                        true = finished parsing HTTP headers,
      *                        indeterminate = not yet finished parsing HTTP headers
      */
-    boost::tribool parse_headers(http::message& http_msg, boost::system::error_code& ec);
+    boost::tribool parse_headers(http::message& http_msg, stdx::error_code& ec);
 
     /**
      * updates an http::message object with data obtained from parsing headers
@@ -476,7 +476,7 @@ protected:
      *                        indeterminate = message is not yet finished
      */
     boost::tribool parse_chunks(http::message::chunk_cache_t& chunk_buffers,
-        boost::system::error_code& ec);
+        stdx::error_code& ec);
 
     /**
      * consumes payload content in the parser's read buffer 
@@ -490,7 +490,7 @@ protected:
      *                        indeterminate = message is not yet finished
      */
     boost::tribool consume_content(http::message& http_msg,
-        boost::system::error_code& ec);
+        stdx::error_code& ec);
 
     /**
      * consume the bytes available in the read buffer, converting them into
@@ -514,8 +514,8 @@ protected:
      * @param ec error code variable to define
      * @param ev error value to raise
      */
-    static inline void set_error(boost::system::error_code& ec, error_value_t ev) {
-        ec = boost::system::error_code(static_cast<int>(ev), get_error_category());
+    static inline void set_error(stdx::error_code& ec, error_value_t ev) {
+        ec = stdx::error_code(static_cast<int>(ev), get_error_category());
     }
 
     /// creates the unique parser error_category_t

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -311,7 +311,7 @@ public:
      * @return true if the URI was successfully parsed, false if there was an error
      */
     static bool parse_uri(const std::string& uri, std::string& proto, 
-                         std::string& host, boost::uint16_t& port, std::string& path,
+                         std::string& host, stdx::uint16_t& port, std::string& path,
                          std::string& query);
 
     /**
@@ -532,34 +532,34 @@ protected:
 
 
     /// maximum length for response status message
-    static const boost::uint32_t        STATUS_MESSAGE_MAX;
+    static const stdx::uint32_t        STATUS_MESSAGE_MAX;
 
     /// maximum length for the request method
-    static const boost::uint32_t        METHOD_MAX;
+    static const stdx::uint32_t        METHOD_MAX;
 
     /// maximum length for the resource requested
-    static const boost::uint32_t        RESOURCE_MAX;
+    static const stdx::uint32_t        RESOURCE_MAX;
 
     /// maximum length for the query string
-    static const boost::uint32_t        QUERY_STRING_MAX;
+    static const stdx::uint32_t        QUERY_STRING_MAX;
 
     /// maximum length for an HTTP header name
-    static const boost::uint32_t        HEADER_NAME_MAX;
+    static const stdx::uint32_t        HEADER_NAME_MAX;
 
     /// maximum length for an HTTP header value
-    static const boost::uint32_t        HEADER_VALUE_MAX;
+    static const stdx::uint32_t        HEADER_VALUE_MAX;
 
     /// maximum length for the name of a query string variable
-    static const boost::uint32_t        QUERY_NAME_MAX;
+    static const stdx::uint32_t        QUERY_NAME_MAX;
 
     /// maximum length for the value of a query string variable
-    static const boost::uint32_t        QUERY_VALUE_MAX;
+    static const stdx::uint32_t        QUERY_VALUE_MAX;
 
     /// maximum length for the name of a cookie name
-    static const boost::uint32_t        COOKIE_NAME_MAX;
+    static const stdx::uint32_t        COOKIE_NAME_MAX;
 
     /// maximum length for the value of a cookie; also used for path and domain
-    static const boost::uint32_t        COOKIE_VALUE_MAX;
+    static const stdx::uint32_t        COOKIE_VALUE_MAX;
 
 
     /// primary logging interface used by this class
@@ -624,7 +624,7 @@ private:
     payload_handler_t                   m_payload_handler;
 
     /// Used for parsing the HTTP response status code
-    boost::uint16_t                     m_status_code;
+    stdx::uint16_t                     m_status_code;
 
     /// Used for parsing the HTTP response status message
     std::string                         m_status_message;

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -12,13 +12,13 @@
 
 #include <string>
 #include <boost/noncopyable.hpp>
-#include <boost/function/function2.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread/once.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/http/message.hpp>
+#include <pion/stdx/functional.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
     #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
@@ -46,7 +46,7 @@ public:
     static const std::size_t        DEFAULT_CONTENT_MAX;
 
     /// callback type used to consume payload content
-    typedef boost::function2<void, const char *, std::size_t>   payload_handler_t;
+    typedef stdx::function<void(const char *, std::size_t)>   payload_handler_t;
     
     /// class-specific error code values
     enum error_value_t {

--- a/include/pion/http/plugin_server.hpp
+++ b/include/pion/http/plugin_server.hpp
@@ -11,7 +11,6 @@
 #define __PION_PLUGIN_SERVER_HEADER__
 
 #include <string>
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
@@ -19,6 +18,7 @@
 #include <pion/plugin_manager.hpp>
 #include <pion/http/server.hpp>
 #include <pion/http/plugin_service.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -53,7 +53,7 @@ public:
      * 
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    explicit plugin_server(const boost::asio::ip::tcp::endpoint& endpoint)
+    explicit plugin_server(const stdx::asio::ip::tcp::endpoint& endpoint)
         : http::server(endpoint)
     { 
         set_logger(PION_GET_LOGGER("pion.http.plugin_server"));
@@ -77,7 +77,7 @@ public:
      * @param sched the scheduler that will be used to manage worker threads
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    plugin_server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
+    plugin_server(scheduler& sched, const stdx::asio::ip::tcp::endpoint& endpoint)
         : http::server(sched, endpoint)
     { 
         set_logger(PION_GET_LOGGER("pion.http.plugin_server"));

--- a/include/pion/http/plugin_server.hpp
+++ b/include/pion/http/plugin_server.hpp
@@ -11,7 +11,6 @@
 #define __PION_PLUGIN_SERVER_HEADER__
 
 #include <string>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/plugin.hpp>
 #include <pion/plugin_manager.hpp>
@@ -19,6 +18,7 @@
 #include <pion/http/plugin_service.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -159,7 +159,7 @@ private:
 
 
 /// data type for a web server pointer
-typedef boost::shared_ptr<plugin_server>        plugin_server_ptr;
+typedef stdx::shared_ptr<plugin_server>        plugin_server_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/plugin_server.hpp
+++ b/include/pion/http/plugin_server.hpp
@@ -11,7 +11,6 @@
 #define __PION_PLUGIN_SERVER_HEADER__
 
 #include <string>
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/plugin.hpp>
@@ -19,6 +18,7 @@
 #include <pion/http/server.hpp>
 #include <pion/http/plugin_service.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -137,13 +137,13 @@ protected:
     /// called before the TCP server starts listening for new connections
     virtual void before_starting(void) {
         // call the start() method for each web service associated with this server
-        m_services.run(boost::bind(&http::plugin_service::start, _1));
+        m_services.run(stdx::bind(&http::plugin_service::start, stdx::placeholders::_1));
     }
     
     /// called after the TCP server has stopped listening for new connections
     virtual void after_stopping(void) {
         // call the stop() method for each web service associated with this server
-        m_services.run(boost::bind(&http::plugin_service::stop, _1));
+        m_services.run(stdx::bind(&http::plugin_service::stop, stdx::placeholders::_1));
     }
 
     

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -10,12 +10,12 @@
 #ifndef __PION_HTTP_READER_HEADER__
 #define __PION_HTTP_READER_HEADER__
 
-#include <boost/asio.hpp>
 #include <pion/config.hpp>
 #include <pion/http/parser.hpp>
 #include <pion/http/message.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/tcp/timer.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -40,7 +40,7 @@ public:
     inline tcp::connection_ptr& get_connection(void) { return m_tcp_conn; }
     
     /// sets the maximum number of seconds for read operations
-    inline void set_timeout(boost::uint32_t seconds) { m_read_timeout = seconds; }
+    inline void set_timeout(stdx::uint32_t seconds) { m_read_timeout = seconds; }
 
     
 protected:
@@ -93,7 +93,7 @@ private:
 
 
     /// default maximum number of seconds for read operations
-    static const boost::uint32_t            DEFAULT_READ_TIMEOUT;
+    static const stdx::uint32_t            DEFAULT_READ_TIMEOUT;
 
 
     /// The HTTP connection that has a new HTTP message to parse
@@ -103,7 +103,7 @@ private:
     tcp::timer_ptr                             m_timer_ptr;
 
     /// maximum number of seconds for read operations
-    boost::uint32_t                         m_read_timeout;
+    stdx::uint32_t                         m_read_timeout;
 };
 
 

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -63,7 +63,7 @@ protected:
      * @param read_error error status from the last read operation
      * @param bytes_read number of bytes consumed by the last read operation
      */
-    void consume_bytes(const boost::system::error_code& read_error,
+    void consume_bytes(const stdx::error_code& read_error,
                       std::size_t bytes_read);
 
     /// Consumes bytes that have been read using an HTTP parser
@@ -73,7 +73,7 @@ protected:
     virtual void read_bytes(void) = 0;
 
     /// Called after we have finished reading/parsing the HTTP message
-    virtual void finished_reading(const boost::system::error_code& ec) = 0;
+    virtual void finished_reading(const stdx::error_code& ec) = 0;
 
     /// Returns a reference to the HTTP message being parsed
     virtual http::message& get_message(void) = 0;
@@ -89,7 +89,7 @@ private:
      *
      * @param read_error error status from the last read operation
      */
-    void handle_read_error(const boost::system::error_code& read_error);
+    void handle_read_error(const stdx::error_code& read_error);
 
 
     /// default maximum number of seconds for read operations

--- a/include/pion/http/request.hpp
+++ b/include/pion/http/request.hpp
@@ -10,10 +10,10 @@
 #ifndef __PION_HTTP_REQUEST_HEADER__
 #define __PION_HTTP_REQUEST_HEADER__
 
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/http/message.hpp>
 #include <pion/user.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -214,7 +214,7 @@ private:
 
 
 /// data type for a HTTP request pointer
-typedef boost::shared_ptr<request>      request_ptr;
+typedef stdx::shared_ptr<request>      request_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/request_reader.hpp
+++ b/include/pion/http/request_reader.hpp
@@ -10,13 +10,12 @@
 #ifndef __PION_HTTP_REQUEST_READER_HEADER__
 #define __PION_HTTP_REQUEST_READER_HEADER__
 
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/reader.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 namespace pion {    // begin namespace pion
 namespace http {    // begin namespace http
@@ -27,7 +26,7 @@ namespace http {    // begin namespace http
 ///
 class request_reader :
     public http::reader,
-    public boost::enable_shared_from_this<request_reader>
+    public stdx::enable_shared_from_this<request_reader>
 {
 
 public:
@@ -46,10 +45,10 @@ public:
      * @param tcp_conn TCP connection containing a new message to parse
      * @param handler function called after the message has been parsed
      */
-    static inline boost::shared_ptr<request_reader>
+    static inline stdx::shared_ptr<request_reader>
         create(const tcp::connection_ptr& tcp_conn, finished_handler_t handler)
     {
-        return boost::shared_ptr<request_reader>
+        return stdx::shared_ptr<request_reader>
             (new request_reader(tcp_conn, handler));
     }
     
@@ -112,7 +111,7 @@ protected:
 
 
 /// data type for a request_reader pointer
-typedef boost::shared_ptr<request_reader>    request_reader_ptr;
+typedef stdx::shared_ptr<request_reader>    request_reader_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/request_reader.hpp
+++ b/include/pion/http/request_reader.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_REQUEST_READER_HEADER__
 #define __PION_HTTP_REQUEST_READER_HEADER__
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/function/function2.hpp>
@@ -19,6 +18,7 @@
 #include <pion/config.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/reader.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -80,8 +80,9 @@ protected:
     virtual void read_bytes(void) {
         get_connection()->async_read_some(boost::bind(&request_reader::consume_bytes,
                                                         shared_from_this(),
-                                                        boost::asio::placeholders::error,
-                                                        boost::asio::placeholders::bytes_transferred));
+                                                        stdx::asio::placeholders::error,
+                                                        stdx::asio::placeholders::bytes_transferred
+                                              ));
     }
 
     /// Called after we have finished parsing the HTTP message headers

--- a/include/pion/http/request_reader.hpp
+++ b/include/pion/http/request_reader.hpp
@@ -34,7 +34,7 @@ public:
 
     /// function called after the HTTP message has been parsed
     typedef stdx::function<void(http::request_ptr, tcp::connection_ptr,
-        const boost::system::error_code&)>   finished_handler_t;
+        const stdx::error_code&)>   finished_handler_t;
 
     
     // default destructor
@@ -86,13 +86,13 @@ protected:
     }
 
     /// Called after we have finished parsing the HTTP message headers
-    virtual void finished_parsing_headers(const boost::system::error_code& ec) {
+    virtual void finished_parsing_headers(const stdx::error_code& ec) {
         // call the finished headers handler with the HTTP message
         if (m_parsed_headers) m_parsed_headers(m_http_msg, get_connection(), ec);
     }
     
     /// Called after we have finished reading/parsing the HTTP message
-    virtual void finished_reading(const boost::system::error_code& ec) {
+    virtual void finished_reading(const stdx::error_code& ec) {
         // call the finished handler with the finished HTTP message
         if (m_finished) m_finished(m_http_msg, get_connection(), ec);
     }

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_REQUEST_WRITER_HEADER__
 #define __PION_HTTP_REQUEST_WRITER_HEADER__
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
@@ -18,6 +17,7 @@
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -126,8 +126,8 @@ protected:
     /// returns a function bound to http::writer::handle_write()
     virtual write_handler_t bind_to_write_handler(void) {
         return boost::bind(&request_writer::handle_write, shared_from_this(),
-                           boost::asio::placeholders::error,
-                           boost::asio::placeholders::bytes_transferred);
+                           stdx::asio::placeholders::error,
+                           stdx::asio::placeholders::bytes_transferred);
     }
 
     /**

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -136,7 +136,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    virtual void handle_write(const boost::system::error_code& write_error,
+    virtual void handle_write(const stdx::error_code& write_error,
                              std::size_t bytes_written)
     {
         (void)bytes_written;

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -11,13 +11,12 @@
 #define __PION_HTTP_REQUEST_WRITER_HEADER__
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -29,7 +28,7 @@ namespace http {    // begin namespace http
 /// 
 class request_writer :
     public http::writer,
-    public boost::enable_shared_from_this<request_writer>
+    public stdx::enable_shared_from_this<request_writer>
 {
 public:
     
@@ -42,13 +41,13 @@ public:
      * @param tcp_conn TCP connection used to send the request
      * @param handler function called after the request has been sent
      * 
-     * @return boost::shared_ptr<request_writer> shared pointer to
+     * @return stdx::shared_ptr<request_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline stdx::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
                                                               finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<request_writer>(new request_writer(tcp_conn, handler));
+        return stdx::shared_ptr<request_writer>(new request_writer(tcp_conn, handler));
     }
     
     /**
@@ -58,14 +57,14 @@ public:
      * @param http_request_ptr pointer to the request that will be sent
      * @param handler function called after the request has been sent
      * 
-     * @return boost::shared_ptr<request_writer> shared pointer to
+     * @return stdx::shared_ptr<request_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline stdx::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
                                                               const http::request_ptr& http_request_ptr,
                                                               finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<request_writer>(new request_writer(tcp_conn, http_request_ptr, handler));
+        return stdx::shared_ptr<request_writer>(new request_writer(tcp_conn, http_request_ptr, handler));
     }
 
     /// returns a non-const reference to the request that will be sent
@@ -166,7 +165,7 @@ private:
 
 
 /// data type for a request_writer pointer
-typedef boost::shared_ptr<request_writer>    request_writer_ptr;
+typedef stdx::shared_ptr<request_writer>    request_writer_ptr;
 
 
 /// override operator<< for convenience

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_REQUEST_WRITER_HEADER__
 #define __PION_HTTP_REQUEST_WRITER_HEADER__
 
-#include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
@@ -18,6 +17,7 @@
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -125,7 +125,7 @@ protected:
 
     /// returns a function bound to http::writer::handle_write()
     virtual write_handler_t bind_to_write_handler(void) {
-        return boost::bind(&request_writer::handle_write, shared_from_this(),
+        return stdx::bind(&request_writer::handle_write, shared_from_this(),
                            stdx::asio::placeholders::error,
                            stdx::asio::placeholders::bytes_transferred);
     }

--- a/include/pion/http/response.hpp
+++ b/include/pion/http/response.hpp
@@ -10,11 +10,11 @@
 #ifndef __PION_HTTP_RESPONSE_HEADER__
 #define __PION_HTTP_RESPONSE_HEADER__
 
-#include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 #include <pion/config.hpp>
 #include <pion/http/message.hpp>
 #include <pion/http/request.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -234,7 +234,7 @@ private:
 
 
 /// data type for a HTTP response pointer
-typedef boost::shared_ptr<response>     response_ptr;
+typedef stdx::shared_ptr<response>     response_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/response_reader.hpp
+++ b/include/pion/http/response_reader.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_RESPONSE_READER_HEADER__
 #define __PION_HTTP_RESPONSE_READER_HEADER__
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/function/function2.hpp>
@@ -19,6 +18,7 @@
 #include <pion/config.hpp>
 #include <pion/http/response.hpp>
 #include <pion/http/reader.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -84,8 +84,8 @@ protected:
     virtual void read_bytes(void) {
         get_connection()->async_read_some(boost::bind(&response_reader::consume_bytes,
                                                         shared_from_this(),
-                                                        boost::asio::placeholders::error,
-                                                        boost::asio::placeholders::bytes_transferred));
+                                                        stdx::asio::placeholders::error,
+                                                        stdx::asio::placeholders::bytes_transferred));
     }
 
     /// Called after we have finished parsing the HTTP message headers

--- a/include/pion/http/response_reader.hpp
+++ b/include/pion/http/response_reader.hpp
@@ -35,7 +35,7 @@ public:
 
     /// function called after the HTTP message has been parsed
     typedef stdx::function<void(http::response_ptr, tcp::connection_ptr,
-        const boost::system::error_code&)>   finished_handler_t;
+        const stdx::error_code&)>   finished_handler_t;
 
     
     // default destructor
@@ -87,13 +87,13 @@ protected:
     }
 
     /// Called after we have finished parsing the HTTP message headers
-    virtual void finished_parsing_headers(const boost::system::error_code& ec) {
+    virtual void finished_parsing_headers(const stdx::error_code& ec) {
         // call the finished headers handler with the HTTP message
         if (m_parsed_headers) m_parsed_headers(m_http_msg, get_connection(), ec);
     }
     
     /// Called after we have finished reading/parsing the HTTP message
-    virtual void finished_reading(const boost::system::error_code& ec) {
+    virtual void finished_reading(const stdx::error_code& ec) {
         // call the finished handler with the finished HTTP message
         if (m_finished) m_finished(m_http_msg, get_connection(), ec);
     }

--- a/include/pion/http/response_reader.hpp
+++ b/include/pion/http/response_reader.hpp
@@ -10,13 +10,12 @@
 #ifndef __PION_HTTP_RESPONSE_READER_HEADER__
 #define __PION_HTTP_RESPONSE_READER_HEADER__
 
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/response.hpp>
 #include <pion/http/reader.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -28,7 +27,7 @@ namespace http {    // begin namespace http
 ///
 class response_reader :
     public http::reader,
-    public boost::enable_shared_from_this<response_reader>
+    public stdx::enable_shared_from_this<response_reader>
 {
 
 public:
@@ -48,11 +47,11 @@ public:
      * @param http_request the request we are responding to
      * @param handler function called after the message has been parsed
      */
-    static inline boost::shared_ptr<response_reader>
+    static inline stdx::shared_ptr<response_reader>
         create(const tcp::connection_ptr& tcp_conn, const http::request& http_request,
                finished_handler_t handler)
     {
-        return boost::shared_ptr<response_reader>
+        return stdx::shared_ptr<response_reader>
             (new response_reader(tcp_conn, http_request, handler));
     }
 
@@ -114,7 +113,7 @@ protected:
 
 
 /// data type for a response_reader pointer
-typedef boost::shared_ptr<response_reader>   response_reader_ptr;
+typedef stdx::shared_ptr<response_reader>   response_reader_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/response_reader.hpp
+++ b/include/pion/http/response_reader.hpp
@@ -10,15 +10,13 @@
 #ifndef __PION_HTTP_RESPONSE_READER_HEADER__
 #define __PION_HTTP_RESPONSE_READER_HEADER__
 
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function2.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/response.hpp>
 #include <pion/http/reader.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -36,8 +34,8 @@ class response_reader :
 public:
 
     /// function called after the HTTP message has been parsed
-    typedef boost::function3<void, http::response_ptr, tcp::connection_ptr,
-        const boost::system::error_code&>   finished_handler_t;
+    typedef stdx::function<void(http::response_ptr, tcp::connection_ptr,
+        const boost::system::error_code&)>   finished_handler_t;
 
     
     // default destructor
@@ -82,7 +80,7 @@ protected:
         
     /// Reads more bytes from the TCP connection
     virtual void read_bytes(void) {
-        get_connection()->async_read_some(boost::bind(&response_reader::consume_bytes,
+        get_connection()->async_read_some(stdx::bind(&response_reader::consume_bytes,
                                                         shared_from_this(),
                                                         stdx::asio::placeholders::error,
                                                         stdx::asio::placeholders::bytes_transferred));

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_RESPONSE_WRITER_HEADER__
 #define __PION_HTTP_RESPONSE_WRITER_HEADER__
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
@@ -19,6 +18,7 @@
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/response.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -134,8 +134,8 @@ protected:
     /// returns a function bound to http::writer::handle_write()
     virtual write_handler_t bind_to_write_handler(void) {
         return boost::bind(&response_writer::handle_write, shared_from_this(),
-                           boost::asio::placeholders::error,
-                           boost::asio::placeholders::bytes_transferred);
+                           stdx::asio::placeholders::error,
+                           stdx::asio::placeholders::bytes_transferred);
     }
 
     /**

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -144,7 +144,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    virtual void handle_write(const boost::system::error_code& write_error,
+    virtual void handle_write(const stdx::error_code& write_error,
                              std::size_t bytes_written)
     {
         (void)bytes_written;

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_RESPONSE_WRITER_HEADER__
 #define __PION_HTTP_RESPONSE_WRITER_HEADER__
 
-#include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
@@ -19,6 +18,7 @@
 #include <pion/http/request.hpp>
 #include <pion/http/response.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -133,7 +133,7 @@ protected:
 
     /// returns a function bound to http::writer::handle_write()
     virtual write_handler_t bind_to_write_handler(void) {
-        return boost::bind(&response_writer::handle_write, shared_from_this(),
+        return stdx::bind(&response_writer::handle_write, shared_from_this(),
                            stdx::asio::placeholders::error,
                            stdx::asio::placeholders::bytes_transferred);
     }

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -11,14 +11,13 @@
 #define __PION_HTTP_RESPONSE_WRITER_HEADER__
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/response.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -30,7 +29,7 @@ namespace http {    // begin namespace http
 /// 
 class PION_API response_writer :
     public http::writer,
-    public boost::enable_shared_from_this<response_writer>
+    public stdx::enable_shared_from_this<response_writer>
 {
 public:
     
@@ -44,14 +43,14 @@ public:
      * @param http_response pointer to the response that will be sent
      * @param handler function called after the response has been sent
      * 
-     * @return boost::shared_ptr<response_writer> shared pointer to
+     * @return stdx::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline stdx::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
                                                             const http::response_ptr& http_response_ptr,
                                                             finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_response_ptr, handler));
+        return stdx::shared_ptr<response_writer>(new response_writer(tcp_conn, http_response_ptr, handler));
     }
 
     /**
@@ -61,14 +60,14 @@ public:
      * @param http_request the request we are responding to
      * @param handler function called after the request has been sent
      * 
-     * @return boost::shared_ptr<response_writer> shared pointer to
+     * @return stdx::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline stdx::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
                                                             const http::request& http_request,
                                                             finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_request, handler));
+        return stdx::shared_ptr<response_writer>(new response_writer(tcp_conn, http_request, handler));
     }
     
     /// returns a non-const reference to the response that will be sent
@@ -174,7 +173,7 @@ private:
 
 
 /// data type for a response_writer pointer
-typedef boost::shared_ptr<response_writer>   response_writer_ptr;
+typedef stdx::shared_ptr<response_writer>   response_writer_ptr;
 
 
 /// override operator<< for convenience

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -237,7 +237,7 @@ protected:
      * @param ec error_code contains additional information for parsing errors
      */
     virtual void handle_request(const http::request_ptr& http_request_ptr,
-                                const tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec);
+                                const tcp::connection_ptr& tcp_conn, const stdx::error_code& ec);
 
     /**
      * searches for the appropriate request handler to use for a given resource

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -16,7 +16,6 @@
 #include <boost/function/function2.hpp>
 #include <boost/function/function3.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/server.hpp>
 #include <pion/tcp/connection.hpp>
@@ -24,6 +23,7 @@
 #include <pion/http/auth.hpp>
 #include <pion/http/parser.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/mutex.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -147,7 +147,7 @@ public:
     /// clears the collection of resources recognized by the HTTP server
     virtual void clear(void) {
         if (is_listening()) stop();
-        boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+        stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
         m_resources.clear();
     }
 
@@ -280,7 +280,7 @@ private:
     error_handler_t             m_server_error_handler;
 
     /// mutex used to protect access to the resources
-    mutable boost::mutex        m_resource_mutex;
+    mutable stdx::mutex        m_resource_mutex;
 
     /// pointer to authentication handler object
     http::auth_ptr              m_auth_ptr;

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -12,7 +12,6 @@
 
 #include <map>
 #include <string>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/server.hpp>
 #include <pion/tcp/connection.hpp>
@@ -22,6 +21,7 @@
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/mutex.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 namespace pion {    // begin namespace pion
 namespace http {    // begin namespace http
@@ -288,7 +288,7 @@ private:
 
 
 /// data type for a HTTP server pointer
-typedef boost::shared_ptr<server>	server_ptr;
+typedef stdx::shared_ptr<server>	server_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -12,9 +12,6 @@
 
 #include <map>
 #include <string>
-#include <boost/function.hpp>
-#include <boost/function/function2.hpp>
-#include <boost/function/function3.hpp>
 #include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/server.hpp>
@@ -24,7 +21,7 @@
 #include <pion/http/parser.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/mutex.hpp>
-
+#include <pion/stdx/functional.hpp>
 
 namespace pion {    // begin namespace pion
 namespace http {    // begin namespace http
@@ -40,11 +37,11 @@ class PION_API server :
 public:
 
     /// type of function that is used to handle requests
-    typedef boost::function2<void, const http::request_ptr&, const tcp::connection_ptr&>  request_handler_t;
+    typedef stdx::function<void(const http::request_ptr&, const tcp::connection_ptr&)>  request_handler_t;
 
     /// handler for requests that result in "500 Server Error"
-    typedef boost::function3<void, const http::request_ptr&, const tcp::connection_ptr&,
-        const std::string&> error_handler_t;
+    typedef stdx::function<void(const http::request_ptr&, const tcp::connection_ptr&,
+        const std::string&)> error_handler_t;
 
 
     /// default destructor

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -12,7 +12,6 @@
 
 #include <map>
 #include <string>
-#include <boost/asio.hpp>
 #include <boost/function.hpp>
 #include <boost/function/function2.hpp>
 #include <boost/function/function3.hpp>
@@ -24,6 +23,7 @@
 #include <pion/http/request.hpp>
 #include <pion/http/auth.hpp>
 #include <pion/http/parser.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -70,7 +70,7 @@ public:
      * 
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    explicit server(const boost::asio::ip::tcp::endpoint& endpoint)
+    explicit server(const stdx::asio::ip::tcp::endpoint& endpoint)
         : tcp::server(endpoint),
         m_bad_request_handler(server::handle_bad_request),
         m_not_found_handler(server::handle_not_found_request),
@@ -102,7 +102,7 @@ public:
      * @param sched the scheduler that will be used to manage worker threads
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
+    server(scheduler& sched, const stdx::asio::ip::tcp::endpoint& endpoint)
         : tcp::server(sched, endpoint),
         m_bad_request_handler(server::handle_bad_request),
         m_not_found_handler(server::handle_not_found_request),

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -34,10 +34,10 @@ class PION_API writer :
 protected:
     
     /// function called after the HTTP message has been sent
-    typedef stdx::function<void(const boost::system::error_code&)> finished_handler_t;
+    typedef stdx::function<void(const stdx::error_code&)> finished_handler_t;
 
     /// data type for a function that handles write operations
-    typedef stdx::function<void(const boost::system::error_code&,std::size_t)> write_handler_t;
+    typedef stdx::function<void(const stdx::error_code&,std::size_t)> write_handler_t;
     
     
     /**
@@ -59,7 +59,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    virtual void handle_write(const boost::system::error_code& write_error,
+    virtual void handle_write(const stdx::error_code& write_error,
                               std::size_t bytes_written) = 0;
 
     
@@ -74,7 +74,7 @@ protected:
     virtual write_handler_t bind_to_write_handler(void) = 0;
     
     /// called after we have finished sending the HTTP message
-    inline void finished_writing(const boost::system::error_code& ec) {
+    inline void finished_writing(const stdx::error_code& ec) {
         if (m_finished) m_finished(ec);
     }
     

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -16,12 +16,12 @@
 #include <boost/function.hpp>
 #include <boost/function/function0.hpp>
 #include <boost/function/function2.hpp>
-#include <boost/asio.hpp>
 #include <boost/noncopyable.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/http/message.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -137,7 +137,7 @@ public:
     inline void write_no_copy(const std::string& data) {
         if (! data.empty()) {
             flush_content_stream();
-            m_content_buffers.push_back(boost::asio::buffer(data));
+            m_content_buffers.push_back(stdx::asio::buffer(data));
             m_content_length += data.size();
         }
     }
@@ -152,7 +152,7 @@ public:
     inline void write_no_copy(void *data, size_t length) {
         if (length > 0) {
             flush_content_stream();
-            m_content_buffers.push_back(boost::asio::buffer(data, length));
+            m_content_buffers.push_back(stdx::asio::buffer(data, length));
             m_content_length += length;
         }
     }
@@ -276,7 +276,7 @@ private:
             // send data in the write buffers
             m_tcp_conn->async_write(write_buffers, send_handler);
         } else {
-            finished_writing(boost::asio::error::connection_reset);
+            finished_writing(stdx::asio::error::connection_reset);
         }
     }
     
@@ -297,7 +297,7 @@ private:
                 m_content_stream.str("");
                 m_content_length += string_to_add.size();
                 m_text_cache.push_back(string_to_add);
-                m_content_buffers.push_back(boost::asio::buffer(m_text_cache.back()));
+                m_content_buffers.push_back(stdx::asio::buffer(m_text_cache.back()));
             }
             m_stream_is_empty = true;
         }
@@ -312,11 +312,11 @@ private:
                 delete[] i->first;
             }
         }
-        inline boost::asio::const_buffer add(const void *ptr, const size_t size) {
+        inline stdx::asio::const_buffer add(const void *ptr, const size_t size) {
             char *data_ptr = new char[size];
             memcpy(data_ptr, ptr, size);
             push_back( std::make_pair(data_ptr, size) );
-            return boost::asio::buffer(data_ptr, size);
+            return stdx::asio::buffer(data_ptr, size);
         }
     };
     

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -13,16 +13,13 @@
 #include <vector>
 #include <string>
 #include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function0.hpp>
-#include <boost/function/function2.hpp>
 #include <boost/noncopyable.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/http/message.hpp>
 #include <pion/stdx/asio.hpp>
-
+#include <pion/stdx/functional.hpp>
 
 namespace pion {    // begin namespace pion
 namespace http {    // begin namespace http
@@ -37,10 +34,10 @@ class PION_API writer :
 protected:
     
     /// function called after the HTTP message has been sent
-    typedef boost::function1<void,const boost::system::error_code&> finished_handler_t;
+    typedef stdx::function<void(const boost::system::error_code&)> finished_handler_t;
 
     /// data type for a function that handles write operations
-    typedef boost::function2<void,const boost::system::error_code&,std::size_t> write_handler_t;
+    typedef stdx::function<void(const boost::system::error_code&,std::size_t)> write_handler_t;
     
     
     /**

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -12,7 +12,6 @@
 
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
@@ -20,6 +19,7 @@
 #include <pion/http/message.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 namespace pion {    // begin namespace pion
 namespace http {    // begin namespace http
@@ -360,7 +360,7 @@ private:
 
 
 /// data type for a writer pointer
-typedef boost::shared_ptr<writer>   writer_ptr;
+typedef stdx::shared_ptr<writer>   writer_ptr;
 
 
 /// override operator<< for convenience

--- a/include/pion/logger.hpp
+++ b/include/pion/logger.hpp
@@ -11,6 +11,7 @@
 #define __PION_LOGGER_HEADER__
 
 #include <pion/config.hpp>
+#include <pion/stdx/mutex.hpp>
 
 
 #if defined(PION_USE_LOG4CXX)
@@ -78,8 +79,7 @@
     #include <log4cplus/loggingmacros.h>
 
     #include <boost/circular_buffer.hpp>
-    #include <boost/thread/mutex.hpp>
-
+    
     #if defined(_MSC_VER) && !defined(PION_CMAKE_BUILD)
         #if defined _DEBUG
             #if defined PION_STATIC_LINKING
@@ -123,7 +123,7 @@
             virtual void close() {}
         protected:
             virtual void append(const log4cplus::spi::InternalLoggingEvent& event) {
-                boost::mutex::scoped_lock log_lock(m_log_mutex);
+                stdx::lock_guard<stdx::mutex> log_lock(m_log_mutex);
                 m_log_events.push_back(*event.clone());
             }
 
@@ -132,7 +132,7 @@
             LogEventBuffer  m_log_events;
 
             /// mutex to make class thread-safe
-            boost::mutex    m_log_mutex;
+            stdx::mutex    m_log_mutex;
         };
     }
 

--- a/include/pion/plugin.hpp
+++ b/include/pion/plugin.hpp
@@ -16,10 +16,10 @@
 #include <list>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/once.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/filesystem/path.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
+#include <pion/stdx/mutex.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -210,7 +210,7 @@ private:
         map_type                    m_plugin_map;
         
         /// mutex to make class thread-safe
-        boost::mutex                m_plugin_mutex;
+        stdx::mutex                m_plugin_mutex;
     };
 
     

--- a/include/pion/plugin_manager.hpp
+++ b/include/pion/plugin_manager.hpp
@@ -13,13 +13,12 @@
 #include <map>
 #include <string>
 #include <boost/assert.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function1.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/plugin.hpp>
 #include <pion/stdx/cstdint.hpp>
 #include <pion/stdx/mutex.hpp>
+#include <pion/stdx/functional.hpp>
 
 namespace pion {    // begin namespace pion
 
@@ -32,10 +31,10 @@ class plugin_manager
 public:
 
     /// data type for a function that may be called by the run() method
-    typedef boost::function1<void, PluginType*>    PluginRunFunction;
+    typedef stdx::function<void(PluginType*)>    PluginRunFunction;
 
     /// data type for a function that may be called by the getStat() method
-    typedef boost::function1<stdx::uint64_t, const PluginType*>   PluginStatFunction;
+    typedef stdx::function<stdx::uint64_t(const PluginType*)>   PluginStatFunction;
 
     
     /// default constructor

--- a/include/pion/plugin_manager.hpp
+++ b/include/pion/plugin_manager.hpp
@@ -12,7 +12,6 @@
 
 #include <map>
 #include <string>
-#include <boost/cstdint.hpp>
 #include <boost/assert.hpp>
 #include <boost/function.hpp>
 #include <boost/function/function1.hpp>
@@ -20,7 +19,7 @@
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/plugin.hpp>
-
+#include <pion/stdx/cstdint.hpp>
 
 namespace pion {    // begin namespace pion
 
@@ -36,7 +35,7 @@ public:
     typedef boost::function1<void, PluginType*>    PluginRunFunction;
 
     /// data type for a function that may be called by the getStat() method
-    typedef boost::function1<boost::uint64_t, const PluginType*>   PluginStatFunction;
+    typedef boost::function1<stdx::uint64_t, const PluginType*>   PluginStatFunction;
 
     
     /// default constructor
@@ -150,7 +149,7 @@ public:
      *
      * @param stat_func the statistic function to execute for each plug-in object
      */
-    inline boost::uint64_t get_statistic(PluginStatFunction stat_func) const;
+    inline stdx::uint64_t get_statistic(PluginStatFunction stat_func) const;
     
     /**
      * returns a statistic value for a particular plug-in
@@ -158,7 +157,7 @@ public:
      * @param plugin_id unique identifier associated with the plug-in
      * @param stat_func the statistic function to execute
      */
-    inline boost::uint64_t get_statistic(const std::string& plugin_id,
+    inline stdx::uint64_t get_statistic(const std::string& plugin_id,
                                         PluginStatFunction stat_func) const;
         
     
@@ -356,9 +355,9 @@ inline void plugin_manager<PluginType>::run(const std::string& plugin_id,
 }
 
 template <typename PluginType>
-inline boost::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
+inline stdx::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
 {
-    boost::uint64_t stat_value = 0;
+    stdx::uint64_t stat_value = 0;
     boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
     for (typename pion::plugin_manager<PluginType>::map_type::const_iterator i = m_plugin_map.begin();
          i != m_plugin_map.end(); ++i)
@@ -369,7 +368,7 @@ inline boost::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunct
 }
 
 template <typename PluginType>
-inline boost::uint64_t plugin_manager<PluginType>::get_statistic(const std::string& plugin_id,
+inline stdx::uint64_t plugin_manager<PluginType>::get_statistic(const std::string& plugin_id,
                                                                 PluginStatFunction stat_func) const
 {
     // no need to lock (handled by plugin_manager::get())

--- a/include/pion/process.hpp
+++ b/include/pion/process.hpp
@@ -13,9 +13,9 @@
 #include <string>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/once.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
+#include <pion/stdx/mutex.hpp>
+#include <pion/stdx/condition_variable.hpp>
 
 // Dump file generation support on Windows
 #ifdef PION_WIN32
@@ -99,10 +99,10 @@ protected:
         bool                    shutdown_now;
         
         /// triggered when it is time to shutdown
-        boost::condition        shutdown_cond;
+        stdx::condition_variable        shutdown_cond;
 
         /// used to protect the shutdown condition
-        boost::mutex            shutdown_mutex;
+        stdx::mutex            shutdown_mutex;
 
 // Dump file generation support on Windows
 #ifdef PION_WIN32

--- a/include/pion/scheduler.hpp
+++ b/include/pion/scheduler.hpp
@@ -12,8 +12,6 @@
 
 #include <vector>
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
-#include <boost/function/function0.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/xtime.hpp>
@@ -24,6 +22,7 @@
 #include <pion/stdx/mutex.hpp>
 #include <pion/stdx/condition_variable.hpp>
 #include <pion/stdx/thread.hpp>
+#include <pion/stdx/functional.hpp>
 
 namespace pion {    // begin namespace pion
 
@@ -84,7 +83,7 @@ public:
      *
      * @param work_func work function to be executed
      */
-    virtual void post(boost::function0<void> work_func) {
+     virtual void post(stdx::function<void()> work_func) {
         get_io_service().post(work_func);
     }
     

--- a/include/pion/scheduler.hpp
+++ b/include/pion/scheduler.hpp
@@ -15,7 +15,6 @@
 #include <boost/assert.hpp>
 #include <boost/bind.hpp>
 #include <boost/function/function0.hpp>
-#include <boost/cstdint.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/thread.hpp>
@@ -24,7 +23,7 @@
 #include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
-
+#include <pion/stdx/cstdint.hpp>
 
 namespace pion {    // begin namespace pion
 
@@ -66,10 +65,10 @@ public:
     inline bool is_running(void) const { return m_is_running; }
     
     /// sets the number of threads to be used (these are shared by all servers)
-    inline void set_num_threads(const boost::uint32_t n) { m_num_threads = n; }
+    inline void set_num_threads(const stdx::uint32_t n) { m_num_threads = n; }
     
     /// returns the number of threads currently in use
-    inline boost::uint32_t get_num_threads(void) const { return m_num_threads; }
+    inline stdx::uint32_t get_num_threads(void) const { return m_num_threads; }
 
     /// sets the logger to be used
     inline void set_logger(logger log_ptr) { m_logger = log_ptr; }
@@ -104,7 +103,7 @@ public:
      * @param sleep_sec number of entire seconds to sleep for
      * @param sleep_nsec number of nanoseconds to sleep for (10^-9 in 1 second)
      */
-    inline static void sleep(boost::uint32_t sleep_sec, boost::uint32_t sleep_nsec) {
+    inline static void sleep(stdx::uint32_t sleep_sec, stdx::uint32_t sleep_nsec) {
         boost::system_time wakeup_time(get_wakeup_time(sleep_sec, sleep_nsec));
         boost::thread::sleep(wakeup_time);
     }
@@ -120,7 +119,7 @@ public:
      */
     template <typename ConditionType, typename LockType>
     inline static void sleep(ConditionType& wakeup_condition, LockType& wakeup_lock,
-                             boost::uint32_t sleep_sec, boost::uint32_t sleep_nsec)
+                             stdx::uint32_t sleep_sec, stdx::uint32_t sleep_nsec)
     {
         boost::system_time wakeup_time(get_wakeup_time(sleep_sec, sleep_nsec));
         wakeup_condition.timed_wait(wakeup_lock, wakeup_time);
@@ -141,8 +140,8 @@ protected:
      *
      * @return boost::system_time time to wake up from sleep
      */
-    static boost::system_time get_wakeup_time(boost::uint32_t sleep_sec,
-        boost::uint32_t sleep_nsec);
+    static boost::system_time get_wakeup_time(stdx::uint32_t sleep_sec,
+        stdx::uint32_t sleep_nsec);
 
     /// stops all services used to schedule work
     virtual void stop_services(void) {}
@@ -158,16 +157,16 @@ protected:
     
     
     /// default number of worker threads in the thread pool
-    static const boost::uint32_t    DEFAULT_NUM_THREADS;
+    static const stdx::uint32_t    DEFAULT_NUM_THREADS;
 
     /// number of nanoseconds in one full second (10 ^ 9)
-    static const boost::uint32_t    NSEC_IN_SECOND;
+    static const stdx::uint32_t    NSEC_IN_SECOND;
 
     /// number of microseconds in one full second (10 ^ 6)
-    static const boost::uint32_t    MICROSEC_IN_SECOND;
+    static const stdx::uint32_t    MICROSEC_IN_SECOND;
     
     /// number of seconds a timer should wait for to keep the IO services running
-    static const boost::uint32_t    KEEP_RUNNING_TIMER_SECONDS;
+    static const stdx::uint32_t    KEEP_RUNNING_TIMER_SECONDS;
 
 
     /// mutex to make class thread-safe
@@ -183,10 +182,10 @@ protected:
     boost::condition                m_scheduler_has_stopped;
 
     /// total number of worker threads in the pool
-    boost::uint32_t                 m_num_threads;
+    stdx::uint32_t                 m_num_threads;
 
     /// the scheduler will not shutdown until there are no more active users
-    boost::uint32_t                 m_active_users;
+    stdx::uint32_t                 m_active_users;
 
     /// true if the thread scheduler is running
     bool                            m_is_running;
@@ -315,7 +314,7 @@ public:
      *
      * @param n integer number representing the service object
      */
-    virtual boost::asio::io_service& get_io_service(boost::uint32_t n) {
+    virtual boost::asio::io_service& get_io_service(stdx::uint32_t n) {
         BOOST_ASSERT(n < m_num_threads);
         BOOST_ASSERT(n < m_service_pool.size());
         return m_service_pool[n]->first;
@@ -353,7 +352,7 @@ protected:
     service_pool_type   m_service_pool;
 
     /// the next service to use for scheduling work
-    boost::uint32_t     m_next_service;
+    stdx::uint32_t     m_next_service;
 };
     
     

--- a/include/pion/scheduler.hpp
+++ b/include/pion/scheduler.hpp
@@ -12,7 +12,6 @@
 
 #include <vector>
 #include <boost/assert.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/xtime.hpp>
 #include <pion/config.hpp>
@@ -23,6 +22,7 @@
 #include <pion/stdx/condition_variable.hpp>
 #include <pion/stdx/thread.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 namespace pion {    // begin namespace pion
 
@@ -248,7 +248,7 @@ protected:
 
     
     /// typedef for a pool of worker threads
-    typedef std::vector<boost::shared_ptr<stdx::thread> >  ThreadPool;
+    typedef std::vector<stdx::shared_ptr<stdx::thread> >  ThreadPool;
     
     
     /// pool of threads used to perform work
@@ -316,7 +316,7 @@ public:
     virtual stdx::asio::io_service& get_io_service(void) {
         stdx::lock_guard<stdx::mutex> scheduler_lock(m_mutex);
         while (m_service_pool.size() < m_num_threads) {
-            boost::shared_ptr<service_pair_type>  service_ptr(new service_pair_type());
+            stdx::shared_ptr<service_pair_type>  service_ptr(new service_pair_type());
             m_service_pool.push_back(service_ptr);
         }
         if (++m_next_service >= m_num_threads)
@@ -362,7 +362,7 @@ protected:
     };
     
     /// typedef for a pool of IO services
-    typedef std::vector<boost::shared_ptr<service_pair_type> >        service_pool_type;
+    typedef std::vector<stdx::shared_ptr<service_pair_type> >        service_pool_type;
 
     
     /// pool of IO services used to schedule work

--- a/include/pion/spdy/decompressor.hpp
+++ b/include/pion/spdy/decompressor.hpp
@@ -15,6 +15,7 @@
 #include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/spdy/types.hpp>
+#include <pion/stdx/cstdint.hpp>
 #include <zlib.h>
 
 
@@ -48,9 +49,9 @@ public:
      * @return the uncompressed string, or null on failure
      */
     char* decompress(const char *compressed_data_ptr,
-                     boost::uint32_t stream_id,
+                     stdx::uint32_t stream_id,
                      const spdy_control_frame_info& frame,
-                     boost::uint32_t header_block_length);
+                     stdx::uint32_t header_block_length);
 
     
 protected:
@@ -62,8 +63,8 @@ protected:
      */
     bool spdy_decompress_header(const char *compressed_data_ptr,
                                 z_streamp decomp,
-                                boost::uint32_t length,
-                                boost::uint32_t& uncomp_length);
+                                stdx::uint32_t length,
+                                stdx::uint32_t& uncomp_length);
 
 
 private:
@@ -75,10 +76,10 @@ private:
     z_streamp                           m_response_zstream;
     
     /// dictionary identifier
-    boost::uint32_t                     m_dictionary_id;
+    stdx::uint32_t                     m_dictionary_id;
     
     /// Used for decompressing spdy headers
-    boost::uint8_t                      m_uncompressed_header[MAX_UNCOMPRESSED_DATA_BUF_SIZE];
+    stdx::uint8_t                      m_uncompressed_header[MAX_UNCOMPRESSED_DATA_BUF_SIZE];
 
     // SPDY Dictionary used for zlib decompression
     static const char                   SPDY_ZLIB_DICTIONARY[];

--- a/include/pion/spdy/decompressor.hpp
+++ b/include/pion/spdy/decompressor.hpp
@@ -12,10 +12,10 @@
 
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/spdy/types.hpp>
 #include <pion/stdx/cstdint.hpp>
+#include <pion/stdx/memory.hpp>
 #include <zlib.h>
 
 
@@ -86,7 +86,7 @@ private:
 };
     
 /// data type for a spdy reader pointer
-typedef boost::shared_ptr<decompressor>       decompressor_ptr;
+typedef stdx::shared_ptr<decompressor>       decompressor_ptr;
     
 }   // end namespace spdy
 }   // end namespace pion

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -13,12 +13,12 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/logic/tribool.hpp>
-#include <boost/system/error_code.hpp>
 #include <boost/thread/once.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/spdy/types.hpp>
 #include <pion/spdy/decompressor.hpp>
+#include <pion/stdx/system_error.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
     #ifndef BOOST_NOEXCEPT
@@ -53,7 +53,7 @@ public:
     
     /// class-specific error category
     class error_category_t
-        : public boost::system::error_category
+        : public stdx::error_category
     {
     public:
         const char *name() const BOOST_SYSTEM_NOEXCEPT { return "SPDYParser"; }
@@ -88,7 +88,7 @@ public:
      *                        indeterminate = not yet finished parsing SPDY frame
      */
     boost::tribool parse(http_protocol_info& http_headers,
-                         boost::system::error_code& ec,
+                         stdx::error_code& ec,
                          const decompressor_ptr& decompressor,
                          const char *packet_ptr,
                          stdx::uint32_t& length_packet,
@@ -129,7 +129,7 @@ protected:
     
     /// populates the frame for every spdy packet
     /// Returns false if there was an error else returns true
-    bool populate_frame(boost::system::error_code& ec,
+    bool populate_frame(stdx::error_code& ec,
                         spdy_control_frame_info& frame,
                         stdx::uint32_t& length_packet,
                         stdx::uint32_t& stream_id,
@@ -150,15 +150,15 @@ protected:
      * @param ec error code variable to define
      * @param ev error value to raise
      */
-    static inline void set_error(boost::system::error_code& ec, error_value_t ev) {
-        ec = boost::system::error_code(static_cast<int>(ev), get_error_category());
+    static inline void set_error(stdx::error_code& ec, error_value_t ev) {
+        ec = stdx::error_code(static_cast<int>(ev), get_error_category());
     }
     
     /**
      * parses an the header payload for SPDY
      *
      */
-    void parse_header_payload(boost::system::error_code& ec,
+    void parse_header_payload(stdx::error_code& ec,
                               const decompressor_ptr& decompressor,
                               const spdy_control_frame_info& frame,
                               http_protocol_info& http_headers,
@@ -168,7 +168,7 @@ protected:
      * parses the data for SPDY
      *
      */
-    void parse_spdy_data(boost::system::error_code& ec,
+    void parse_spdy_data(stdx::error_code& ec,
                          const spdy_control_frame_info& frame,
                          stdx::uint32_t stream_id,
                          http_protocol_info& http_info);
@@ -177,35 +177,35 @@ protected:
      * parses an the Settings Frame for SPDY
      *
      */
-    void parse_spdy_settings_frame(boost::system::error_code& ec,
+    void parse_spdy_settings_frame(stdx::error_code& ec,
                                    const spdy_control_frame_info& frame);
     
     /**
      * parses an the RST stream for SPDY
      *
      */
-    void parse_spdy_rst_stream(boost::system::error_code& ec,
+    void parse_spdy_rst_stream(stdx::error_code& ec,
                                const spdy_control_frame_info& frame);
     
     /**
      * parses an the Ping Frame for SPDY
      *
      */
-    void parse_spdy_ping_frame(boost::system::error_code& ec,
+    void parse_spdy_ping_frame(stdx::error_code& ec,
                                const spdy_control_frame_info& frame);
     
     /**
      * parses an the GoAway Frame for SPDY
      *
      */
-    void parse_spdy_goaway_frame(boost::system::error_code& ec,
+    void parse_spdy_goaway_frame(stdx::error_code& ec,
                                  const spdy_control_frame_info& frame);
     
     /**
      * parses an the WindowUpdate Frame for SPDY
      *
      */
-    void parse_spdy_window_update_frame(boost::system::error_code& ec,
+    void parse_spdy_window_update_frame(stdx::error_code& ec,
                                         const spdy_control_frame_info& frame);
     
     /**
@@ -216,7 +216,7 @@ protected:
      *                        true = finished parsing SPDY frame,
      *                        indeterminate = not yet finished parsing SPDY frame
      */
-    boost::tribool parse_spdy_frame(boost::system::error_code& ec,
+    boost::tribool parse_spdy_frame(stdx::error_code& ec,
                                     const decompressor_ptr& decompressor,
                                     http_protocol_info& http_headers,
                                     stdx::uint32_t& length_packet,

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -91,8 +91,8 @@ public:
                          boost::system::error_code& ec,
                          const decompressor_ptr& decompressor,
                          const char *packet_ptr,
-                         boost::uint32_t& length_packet,
-                         boost::uint32_t current_stream_count);
+                         stdx::uint32_t& length_packet,
+                         stdx::uint32_t current_stream_count);
     
     /// Get the pointer to the first character to the spdy data contect 
     const char * get_spdy_data_content( ) { return m_last_data_chunk_ptr; }
@@ -119,7 +119,7 @@ public:
      *
      * @return true if it is a control frame else returns false
      */
-    static boost::uint32_t get_control_frame_stream_id(const char *ptr);
+    static stdx::uint32_t get_control_frame_stream_id(const char *ptr);
     
     
 protected:
@@ -131,8 +131,8 @@ protected:
     /// Returns false if there was an error else returns true
     bool populate_frame(boost::system::error_code& ec,
                         spdy_control_frame_info& frame,
-                        boost::uint32_t& length_packet,
-                        boost::uint32_t& stream_id,
+                        stdx::uint32_t& length_packet,
+                        stdx::uint32_t& stream_id,
                         http_protocol_info& http_headers);
     
     /// creates the unique parser error_category_t
@@ -162,7 +162,7 @@ protected:
                               const decompressor_ptr& decompressor,
                               const spdy_control_frame_info& frame,
                               http_protocol_info& http_headers,
-                              boost::uint32_t current_stream_count);
+                              stdx::uint32_t current_stream_count);
     
     /**
      * parses the data for SPDY
@@ -170,7 +170,7 @@ protected:
      */
     void parse_spdy_data(boost::system::error_code& ec,
                          const spdy_control_frame_info& frame,
-                         boost::uint32_t stream_id,
+                         stdx::uint32_t stream_id,
                          http_protocol_info& http_info);
     
     /**
@@ -219,8 +219,8 @@ protected:
     boost::tribool parse_spdy_frame(boost::system::error_code& ec,
                                     const decompressor_ptr& decompressor,
                                     http_protocol_info& http_headers,
-                                    boost::uint32_t& length_packet,
-                                    boost::uint32_t current_stream_count);
+                                    stdx::uint32_t& length_packet,
+                                    stdx::uint32_t current_stream_count);
     
 private:
     

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -11,7 +11,6 @@
 #define __PION_SPDYPARSER_HEADER__
 
 
-#include <boost/shared_ptr.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/thread/once.hpp>
 #include <pion/config.hpp>
@@ -19,6 +18,7 @@
 #include <pion/spdy/types.hpp>
 #include <pion/spdy/decompressor.hpp>
 #include <pion/stdx/system_error.hpp>
+#include <pion/stdx/memory.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
     #ifndef BOOST_NOEXCEPT
@@ -247,7 +247,7 @@ private:
 };
 
 /// data type for a spdy reader pointer
-typedef boost::shared_ptr<parser>       parser_ptr;
+typedef stdx::shared_ptr<parser>       parser_ptr;
         
         
 }   // end namespace spdy

--- a/include/pion/spdy/types.hpp
+++ b/include/pion/spdy/types.hpp
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <pion/config.hpp>
+#include <pion/stdx/cstdint.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -47,10 +48,10 @@ namespace spdy {    // begin namespace spdy
 /// This structure will be tied to each SPDY frame
 typedef struct spdy_control_frame_info{
     bool control_bit;
-    boost::uint16_t  version;
-    boost::uint16_t  type;
-    boost::uint8_t   flags;
-    boost::uint32_t  length;  // Actually only 24 bits.
+    stdx::uint16_t  version;
+    stdx::uint16_t  type;
+    stdx::uint8_t   flags;
+    stdx::uint32_t  length;  // Actually only 24 bits.
 } spdy_control_frame_info;
 
     
@@ -58,20 +59,20 @@ typedef struct spdy_control_frame_info{
 /// Only applies to frames containing headers: SYN_STREAM, SYN_REPLY, HEADERS
 /// Note that there may be multiple SPDY frames in one packet.
 typedef struct _spdy_header_info{
-    boost::uint32_t stream_id;
-    boost::uint8_t *header_block;
-    boost::uint8_t  header_block_len;
-    boost::uint16_t frame_type;
+    stdx::uint32_t stream_id;
+    stdx::uint8_t *header_block;
+    stdx::uint8_t  header_block_len;
+    stdx::uint16_t frame_type;
 } spdy_header_info;
 
 
 /// This structure contains the HTTP Protocol information
 typedef struct _http_protocol_info_t{
     std::map<std::string, std::string> http_headers;
-    boost::uint32_t     http_type;
-    boost::uint32_t     stream_id;
-    boost::uint32_t     data_offset;
-    boost::uint32_t     data_size;
+    stdx::uint32_t     http_type;
+    stdx::uint32_t     stream_id;
+    stdx::uint32_t     data_offset;
+    stdx::uint32_t     data_size;
     bool                last_chunk;
     
     _http_protocol_info_t()

--- a/include/pion/stdx/asio.hpp
+++ b/include/pion/stdx/asio.hpp
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_ASIO_HEADER__
+#define __PION_STDX_ASIO_HEADER__
+
+#include <pion/config.hpp>
+#include <pion/stdx/functional.hpp>
+
+#if defined(PION_HAVE_STANDALONE_ASIO)
+
+#if !defined(PION_HAVE_CXX11)
+#error "Standalone ASIO mode requires C++11"
+#endif
+
+// Don't use boost types in asio, use the ones from std::
+#define ASIO_STANDALONE
+
+// This is needed so that we have the deadline_timer
+// https://github.com/chriskohlhoff/asio/issues/82
+#define ASIO_HAS_BOOST_DATE_TIME
+
+#include <asio.hpp>
+
+#ifdef PION_HAVE_SSL
+#ifdef PION_XCODE
+// ignore openssl warnings if building with XCode
+#pragma GCC system_header
+#endif
+#include <asio/ssl.hpp>
+#endif
+
+#else
+#include <boost/asio.hpp>
+
+#ifdef PION_HAVE_SSL
+#ifdef PION_XCODE
+// ignore openssl warnings if building with XCode
+#pragma GCC system_header
+#endif
+#include <boost/asio/ssl.hpp>
+#endif
+
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_STANDALONE_ASIO)
+
+namespace asio {
+
+using namespace ::asio;
+
+// In standalone mode, ASIO doesn't define placeholders.
+// https://github.com/chriskohlhoff/asio/issues/83
+namespace placeholders {
+
+const decltype(stdx::placeholders::_1) error{};
+const decltype(stdx::placeholders::_2) bytes_transferred{};
+const decltype(stdx::placeholders::_2) iterator{};
+const decltype(stdx::placeholders::_2) results{};
+const decltype(stdx::placeholders::_2) endpoint{};
+const decltype(stdx::placeholders::_2) signal_number{};
+
+}   // end namespace placeholders
+
+}   // end namespace asio
+
+#else
+
+namespace asio = ::boost::asio;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/condition_variable.hpp
+++ b/include/pion/stdx/condition_variable.hpp
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_CONDITION_HEADER__
+#define __PION_STDX_CONDITION_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <condition_variable>
+#else
+#include <boost/thread/condition.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::condition_variable;
+
+#else
+
+using condition_variable = boost::condition;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/condition_variable.hpp
+++ b/include/pion/stdx/condition_variable.hpp
@@ -25,7 +25,7 @@ using ::std::condition_variable;
 
 #else
 
-using condition_variable = boost::condition;
+typedef boost::condition condition_variable;
 
 #endif
 

--- a/include/pion/stdx/cstdint.hpp
+++ b/include/pion/stdx/cstdint.hpp
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_CSTDINT_HEADER__
+#define __PION_STDX_CSTDINT_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <cstdint>
+#else
+#include <boost/cstdint.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::int8_t;
+using ::std::int16_t;
+using ::std::int32_t;
+using ::std::int64_t;
+using ::std::uint8_t;
+using ::std::uint16_t;
+using ::std::uint32_t;
+using ::std::uint64_t;
+
+#else
+
+using ::boost::int8_t;
+using ::boost::int16_t;
+using ::boost::int32_t;
+using ::boost::int64_t;
+using ::boost::uint8_t;
+using ::boost::uint16_t;
+using ::boost::uint32_t;
+using ::boost::uint64_t;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/functional.hpp
+++ b/include/pion/stdx/functional.hpp
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_FUNCTIONAL_HEADER__
+#define __PION_STDX_FUNCTIONAL_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <functional>
+#else
+#include <boost/function.hpp>
+#include <boost/bind.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::function;
+using ::std::bind;
+using ::std::ref;
+using ::std::cref;
+
+namespace placeholders = ::std::placeholders;
+
+#else
+
+using ::boost::function;
+using ::boost::bind;
+using ::boost::ref;
+using ::boost::cref;
+
+namespace placeholders {
+static ::boost::arg<1> _1;
+static ::boost::arg<2> _2;
+static ::boost::arg<3> _3;
+static ::boost::arg<4> _4;
+static ::boost::arg<5> _5;
+static ::boost::arg<6> _6;
+static ::boost::arg<7> _7;
+static ::boost::arg<8> _8;
+static ::boost::arg<9> _9;
+}   // end namespace placeholders
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/memory.hpp
+++ b/include/pion/stdx/memory.hpp
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_MEMORY_HEADER__
+#define __PION_STDX_MEMORY_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <memory>
+#else
+#include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::shared_ptr;
+using ::std::enable_shared_from_this;
+
+#else
+
+using ::boost::shared_ptr;
+using ::boost::enable_shared_from_this;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/mutex.hpp
+++ b/include/pion/stdx/mutex.hpp
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_MUTEX_HEADER__
+#define __PION_STDX_MUTEX_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <mutex>
+#else
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/locks.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::mutex;
+using ::std::lock_guard;
+using ::std::unique_lock;
+
+#else
+
+using ::boost::mutex;
+using ::boost::lock_guard;
+using ::boost::unique_lock;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/system_error.hpp
+++ b/include/pion/stdx/system_error.hpp
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_SYSTEM_ERROR_HEADER__
+#define __PION_STDX_SYSTEM_ERROR_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <system_error>
+#else
+#include <boost/system/error_code.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::error_code;
+using ::std::error_category;
+using ::std::error_condition;
+using ::std::system_error;
+using ::std::system_category;
+using ::std::errc;
+
+#else
+
+using ::boost::system::error_code;
+using ::boost::system::error_category;
+using ::boost::system::error_condition;
+using ::boost::system::system_error;
+using ::boost::system::system_category;
+
+// Interestingly, in boost, errc is a namespace
+namespace errc = ::boost::system::errc;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/stdx/thread.hpp
+++ b/include/pion/stdx/thread.hpp
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------
+// pion:  a Boost C++ framework for building lightweight HTTP interfaces
+// ---------------------------------------------------------------------
+// Copyright (C) 2015 Splunk Inc.  (https://github.com/splunk/pion)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+//
+
+#ifndef __PION_STDX_THREAD_HEADER__
+#define __PION_STDX_THREAD_HEADER__
+
+#if defined(PION_HAVE_CXX11)
+#include <thread>
+#else
+#include <boost/thread/thread.hpp>
+#endif
+
+namespace pion {    // begin namespace pion
+namespace stdx {    // begin namespace stdx
+
+#if defined(PION_HAVE_CXX11)
+
+using ::std::thread;
+namespace this_thread = ::std::this_thread;
+
+#else
+
+using ::boost::thread;
+
+#endif
+
+}   // end namespace stdx
+}   // end namespace pion
+
+#endif

--- a/include/pion/tcp/connection.hpp
+++ b/include/pion/tcp/connection.hpp
@@ -18,6 +18,7 @@
 #include <pion/config.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/system_error.hpp>
 #include <string>
 
 
@@ -154,7 +155,7 @@ public:
             } catch (...) {}    // ignore exceptions
             
             // close the underlying socket (ignore errors)
-            boost::system::error_code ec;
+            stdx::error_code ec;
             m_ssl_socket.next_layer().close(ec);
         }
     }
@@ -166,7 +167,7 @@ public:
     /// and the suggested #define statements cause WAY too much trouble and heartache
     inline void cancel(void) {
 #if !defined(_MSC_VER) || (_WIN32_WINNT >= 0x0600)
-        boost::system::error_code ec;
+        stdx::error_code ec;
         m_ssl_socket.next_layer().cancel(ec);
 #endif
     }
@@ -193,13 +194,13 @@ public:
      * accepts a new tcp connection (blocks until established)
      *
      * @param tcp_acceptor object used to accept new connections
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::accept()
      */
-    inline boost::system::error_code accept(stdx::asio::ip::tcp::acceptor& tcp_acceptor)
+    inline stdx::error_code accept(stdx::asio::ip::tcp::acceptor& tcp_acceptor)
     {
-        boost::system::error_code ec;
+        stdx::error_code ec;
         tcp_acceptor.accept(m_ssl_socket.lowest_layer(), ec);
         return ec;
     }
@@ -241,13 +242,13 @@ public:
      * connects to a remote endpoint (blocks until established)
      *
      * @param tcp_endpoint remote endpoint to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(stdx::asio::ip::tcp::endpoint& tcp_endpoint)
+    inline stdx::error_code connect(stdx::asio::ip::tcp::endpoint& tcp_endpoint)
     {
-        boost::system::error_code ec;
+        stdx::error_code ec;
         m_ssl_socket.lowest_layer().connect(tcp_endpoint, ec);
         return ec;
     }
@@ -257,11 +258,11 @@ public:
      *
      * @param remote_addr remote IP address (v4) to connect to
      * @param remote_port remote port number to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(const stdx::asio::ip::address& remote_addr,
+    inline stdx::error_code connect(const stdx::asio::ip::address& remote_addr,
                                              const unsigned int remote_port)
     {
         stdx::asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
@@ -273,15 +274,15 @@ public:
      *
      * @param remote_server hostname of the remote server to connect to
      * @param remote_port remote port number to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(const std::string& remote_server,
+    inline stdx::error_code connect(const std::string& remote_server,
                                              const unsigned int remote_port)
     {
         // query a list of matching endpoints
-        boost::system::error_code ec;
+        stdx::error_code ec;
         stdx::asio::ip::tcp::resolver resolver(m_ssl_socket.lowest_layer().get_io_service());
         stdx::asio::ip::tcp::resolver::query query(remote_server,
             boost::lexical_cast<std::string>(remote_port),
@@ -337,12 +338,12 @@ public:
     /**
      * performs client-side SSL handshake for a new connection (blocks until finished)
      *
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::ssl::stream::handshake()
      */
-    inline boost::system::error_code handshake_client(void) {
-        boost::system::error_code ec;
+    inline stdx::error_code handshake_client(void) {
+        stdx::error_code ec;
 #ifdef PION_HAVE_SSL
         m_ssl_socket.handshake(stdx::asio::ssl::stream_base::client, ec);
         m_ssl_flag = true;
@@ -353,12 +354,12 @@ public:
     /**
      * performs server-side SSL handshake for a new connection (blocks until finished)
      *
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::ssl::stream::handshake()
      */
-    inline boost::system::error_code handshake_server(void) {
-        boost::system::error_code ec;
+    inline stdx::error_code handshake_server(void) {
+        stdx::error_code ec;
 #ifdef PION_HAVE_SSL
         m_ssl_socket.handshake(stdx::asio::ssl::stream_base::server, ec);
         m_ssl_flag = true;
@@ -412,7 +413,7 @@ public:
      *
      * @see stdx::asio::basic_stream_socket::read_some()
      */
-    inline std::size_t read_some(boost::system::error_code& ec) {
+    inline std::size_t read_some(stdx::error_code& ec) {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
             return m_ssl_socket.read_some(stdx::asio::buffer(m_read_buffer), ec);
@@ -432,7 +433,7 @@ public:
      */
     template <typename ReadBufferType>
     inline std::size_t read_some(ReadBufferType read_buffer,
-                                 boost::system::error_code& ec)
+                                 stdx::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
@@ -502,7 +503,7 @@ public:
      */
     template <typename CompletionCondition>
     inline std::size_t read(CompletionCondition completion_condition,
-                            boost::system::error_code& ec)
+                            stdx::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
@@ -528,7 +529,7 @@ public:
     template <typename MutableBufferSequence, typename CompletionCondition>
     inline std::size_t read(const MutableBufferSequence& buffers,
                             CompletionCondition completion_condition,
-                            boost::system::error_code& ec)
+                            stdx::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
@@ -569,7 +570,7 @@ public:
      */
     template <typename ConstBufferSequence>
     inline std::size_t write(const ConstBufferSequence& buffers,
-                             boost::system::error_code& ec)
+                             stdx::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
@@ -632,7 +633,7 @@ public:
         try {
             // const_cast is required since lowest_layer() is only defined non-const in asio
             remote_endpoint = const_cast<ssl_socket_type&>(m_ssl_socket).lowest_layer().remote_endpoint();
-        } catch (boost::system::system_error& /* e */) {
+        } catch (stdx::system_error& /* e */) {
             // do nothing
         }
         return remote_endpoint;

--- a/include/pion/tcp/connection.hpp
+++ b/include/pion/tcp/connection.hpp
@@ -15,10 +15,9 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/array.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function1.hpp>
 #include <pion/config.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 #include <string>
 
 
@@ -44,7 +43,7 @@ public:
     enum { READ_BUFFER_SIZE = 8192 };
     
     /// data type for a function that handles TCP connection objects
-    typedef boost::function1<void, boost::shared_ptr<connection> >   connection_handler;
+    typedef stdx::function<void(boost::shared_ptr<connection>)>   connection_handler;
     
     /// data type for an I/O read buffer
     typedef boost::array<char, READ_BUFFER_SIZE>    read_buffer_type;

--- a/include/pion/tcp/connection.hpp
+++ b/include/pion/tcp/connection.hpp
@@ -11,14 +11,13 @@
 #define __PION_TCP_CONNECTION_HEADER__
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/array.hpp>
 #include <pion/config.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/functional.hpp>
 #include <pion/stdx/system_error.hpp>
+#include <pion/stdx/memory.hpp>
 #include <string>
 
 
@@ -30,7 +29,7 @@ namespace tcp {     // begin namespace tcp
 /// connection: represents a single tcp connection
 /// 
 class connection :
-    public boost::enable_shared_from_this<connection>,
+    public stdx::enable_shared_from_this<connection>,
     private boost::noncopyable
 {
 public:
@@ -44,7 +43,7 @@ public:
     enum { READ_BUFFER_SIZE = 8192 };
     
     /// data type for a function that handles TCP connection objects
-    typedef stdx::function<void(boost::shared_ptr<connection>)>   connection_handler;
+    typedef stdx::function<void(stdx::shared_ptr<connection>)>   connection_handler;
     
     /// data type for an I/O read buffer
     typedef boost::array<char, READ_BUFFER_SIZE>    read_buffer_type;
@@ -83,12 +82,12 @@ public:
      * @param finished_handler function called when a server has finished
      *                         handling the connection
      */
-    static inline boost::shared_ptr<connection> create(stdx::asio::io_service& io_service,
+    static inline stdx::shared_ptr<connection> create(stdx::asio::io_service& io_service,
                                                           ssl_context_type& ssl_context,
                                                           const bool ssl_flag,
                                                           connection_handler finished_handler)
     {
-        return boost::shared_ptr<connection>(new connection(io_service, ssl_context,
+        return stdx::shared_ptr<connection>(new connection(io_service, ssl_context,
                                                                   ssl_flag, finished_handler));
     }
     
@@ -727,7 +726,7 @@ private:
 
 
 /// data type for a connection pointer
-typedef boost::shared_ptr<connection>    connection_ptr;
+typedef stdx::shared_ptr<connection>    connection_ptr;
 
 
 }   // end namespace tcp

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -11,7 +11,6 @@
 #define __PION_TCP_SERVER_HEADER__
 
 #include <set>
-#include <boost/asio.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
@@ -20,6 +19,7 @@
 #include <pion/logger.hpp>
 #include <pion/scheduler.hpp>
 #include <pion/tcp/connection.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -67,16 +67,16 @@ public:
     inline void set_port(unsigned int p) { m_endpoint.port(p); }
     
     /// returns IP address that the server listens for connections on
-    inline boost::asio::ip::address get_address(void) const { return m_endpoint.address(); }
+    inline stdx::asio::ip::address get_address(void) const { return m_endpoint.address(); }
     
     /// sets IP address that the server listens for connections on
-    inline void set_address(const boost::asio::ip::address& addr) { m_endpoint.address(addr); }
+    inline void set_address(const stdx::asio::ip::address& addr) { m_endpoint.address(addr); }
     
     /// returns tcp endpoint that the server listens for connections on
-    inline const boost::asio::ip::tcp::endpoint& get_endpoint(void) const { return m_endpoint; }
+    inline const stdx::asio::ip::tcp::endpoint& get_endpoint(void) const { return m_endpoint; }
     
     /// sets tcp endpoint that the server listens for connections on
-    inline void set_endpoint(const boost::asio::ip::tcp::endpoint& ep) { m_endpoint = ep; }
+    inline void set_endpoint(const stdx::asio::ip::tcp::endpoint& ep) { m_endpoint = ep; }
 
     /// returns true if the server uses SSL to encrypt connections
     inline bool get_ssl_flag(void) const { return m_ssl_flag; }
@@ -97,10 +97,10 @@ public:
     inline logger get_logger(void) { return m_logger; }
     
     /// returns mutable reference to the TCP connection acceptor
-    inline boost::asio::ip::tcp::acceptor& get_acceptor(void) { return m_tcp_acceptor; }
+    inline stdx::asio::ip::tcp::acceptor& get_acceptor(void) { return m_tcp_acceptor; }
 
     /// returns const reference to the TCP connection acceptor
-    inline const boost::asio::ip::tcp::acceptor& get_acceptor(void) const { return m_tcp_acceptor; }
+    inline const stdx::asio::ip::tcp::acceptor& get_acceptor(void) const { return m_tcp_acceptor; }
 
     
 protected:
@@ -117,7 +117,7 @@ protected:
      * 
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    explicit server(const boost::asio::ip::tcp::endpoint& endpoint);
+    explicit server(const stdx::asio::ip::tcp::endpoint& endpoint);
 
     /**
      * protected constructor so that only derived objects may be created
@@ -133,7 +133,7 @@ protected:
      * @param sched the scheduler that will be used to manage worker threads
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint);
+    server(scheduler& sched, const stdx::asio::ip::tcp::endpoint& endpoint);
     
     /**
      * handles a new TCP connection; derived classes SHOULD override this
@@ -153,7 +153,7 @@ protected:
     virtual void after_stopping(void) {}
     
     /// returns an async I/O service used to schedule work
-    inline boost::asio::io_service& get_io_service(void) { return m_active_scheduler.get_io_service(); }
+    inline stdx::asio::io_service& get_io_service(void) { return m_active_scheduler.get_io_service(); }
     
     
     /// primary logging interface used by this class
@@ -208,7 +208,7 @@ private:
     scheduler &                             m_active_scheduler;
     
     /// manages async TCP connections
-    boost::asio::ip::tcp::acceptor          m_tcp_acceptor;
+    stdx::asio::ip::tcp::acceptor          m_tcp_acceptor;
 
     /// context used for SSL configuration
     connection::ssl_context_type            m_ssl_context;
@@ -223,7 +223,7 @@ private:
     ConnectionPool                          m_conn_pool;
 
     /// tcp endpoint used to listen for new connections
-    boost::asio::ip::tcp::endpoint          m_endpoint;
+    stdx::asio::ip::tcp::endpoint          m_endpoint;
 
     /// true if the server uses SSL to encrypt connections
     bool                                    m_ssl_flag;

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -12,7 +12,6 @@
 
 #include <set>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/scheduler.hpp>
@@ -20,6 +19,7 @@
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/mutex.hpp>
 #include <pion/stdx/condition_variable.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -237,7 +237,7 @@ private:
 
 
 /// data type for a server pointer
-typedef boost::shared_ptr<server>    server_ptr;
+typedef stdx::shared_ptr<server>    server_ptr;
 
 
 }   // end namespace tcp

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -175,7 +175,7 @@ private:
      * @param accept_error true if an error occurred while accepting connections
      */
     void handle_accept(const tcp::connection_ptr& tcp_conn,
-                      const boost::system::error_code& accept_error);
+                      const stdx::error_code& accept_error);
 
     /**
      * handles new connections following an SSL handshake (checks for errors)
@@ -184,7 +184,7 @@ private:
      * @param handshake_error true if an error occurred during the SSL handshake
      */
     void handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
-                            const boost::system::error_code& handshake_error);
+                            const stdx::error_code& handshake_error);
     
     /// This will be called by connection::finish() after a server has
     /// finished handling a connection.  If the keep_alive flag is true,

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -13,13 +13,13 @@
 #include <set>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/scheduler.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/mutex.hpp>
+#include <pion/stdx/condition_variable.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -214,10 +214,10 @@ private:
     connection::ssl_context_type            m_ssl_context;
         
     /// condition triggered when the server has stopped listening for connections
-    boost::condition                        m_server_has_stopped;
+    stdx::condition_variable                        m_server_has_stopped;
 
     /// condition triggered when the connection pool is empty
-    boost::condition                        m_no_more_connections;
+    stdx::condition_variable                        m_no_more_connections;
 
     /// pool of active connections associated with this server 
     ConnectionPool                          m_conn_pool;
@@ -232,7 +232,7 @@ private:
     bool                                    m_is_listening;
 
     /// mutex to make class thread-safe
-    mutable boost::mutex                    m_mutex;
+    mutable stdx::mutex                    m_mutex;
 };
 
 

--- a/include/pion/tcp/stream.hpp
+++ b/include/pion/tcp/stream.hpp
@@ -65,7 +65,7 @@ public:
      * @param io_service asio service associated with the connection
      * @param ssl_flag if true then the connection will be encrypted using SSL 
      */
-    explicit stream_buffer(boost::asio::io_service& io_service,
+    explicit stream_buffer(stdx::asio::io_service& io_service,
                              const bool ssl_flag = false)
         : m_conn_ptr(new connection(io_service, ssl_flag)),
         m_read_buf(m_conn_ptr->get_read_buffer().c_array())
@@ -79,7 +79,7 @@ public:
      * @param io_service asio service associated with the connection
      * @param ssl_context asio ssl context associated with the connection
      */
-    stream_buffer(boost::asio::io_service& io_service,
+    stream_buffer(stdx::asio::io_service& io_service,
                     connection::ssl_context_type& ssl_context)
         : m_conn_ptr(new connection(io_service, ssl_context)),
         m_read_buf(m_conn_ptr->get_read_buffer().c_array())
@@ -118,10 +118,10 @@ protected:
         if (bytes_to_send > 0) {
             boost::mutex::scoped_lock async_lock(m_async_mutex);
             m_bytes_transferred = 0;
-            m_conn_ptr->async_write(boost::asio::buffer(pbase(), bytes_to_send),
+            m_conn_ptr->async_write(stdx::asio::buffer(pbase(), bytes_to_send),
                                     boost::bind(&stream_buffer::operation_finished, this,
-                                                boost::asio::placeholders::error,
-                                                boost::asio::placeholders::bytes_transferred));
+                                                stdx::asio::placeholders::error,
+                                                stdx::asio::placeholders::bytes_transferred));
             m_async_done.wait(async_lock);
             bytes_sent = m_bytes_transferred;
             pbump(-bytes_sent);
@@ -155,11 +155,11 @@ protected:
         // be cancelled by other threads and will block forever (such as during shutdown)
         boost::mutex::scoped_lock async_lock(m_async_mutex);
         m_bytes_transferred = 0;
-        m_conn_ptr->async_read_some(boost::asio::buffer(m_read_buf+PUT_BACK_MAX,
+        m_conn_ptr->async_read_some(stdx::asio::buffer(m_read_buf+PUT_BACK_MAX,
                                                         connection::READ_BUFFER_SIZE-PUT_BACK_MAX),
                                     boost::bind(&stream_buffer::operation_finished, this,
-                                                boost::asio::placeholders::error,
-                                                boost::asio::placeholders::bytes_transferred));
+                                                stdx::asio::placeholders::error,
+                                                stdx::asio::placeholders::bytes_transferred));
         m_async_done.wait(async_lock);
         if (m_async_error)
             return traits_type::eof();
@@ -223,11 +223,11 @@ protected:
                 // send it all now rather than buffering
                 boost::mutex::scoped_lock async_lock(m_async_mutex);
                 m_bytes_transferred = 0;
-                m_conn_ptr->async_write(boost::asio::buffer(s+bytes_available,
+                m_conn_ptr->async_write(stdx::asio::buffer(s+bytes_available,
                                                             n-bytes_available),
                                         boost::bind(&stream_buffer::operation_finished, this,
-                                                    boost::asio::placeholders::error,
-                                                    boost::asio::placeholders::bytes_transferred));
+                                                    stdx::asio::placeholders::error,
+                                                    stdx::asio::placeholders::bytes_transferred));
                 m_async_done.wait(async_lock);
                 bytes_sent = bytes_available + m_bytes_transferred;
             } else {
@@ -351,7 +351,7 @@ public:
      * @param io_service asio service associated with the connection
      * @param ssl_flag if true then the connection will be encrypted using SSL 
      */
-    explicit stream(boost::asio::io_service& io_service,
+    explicit stream(stdx::asio::io_service& io_service,
                        const bool ssl_flag = false)
         : std::basic_iostream<char, std::char_traits<char> >(NULL), m_tcp_buf(io_service, ssl_flag)
     {
@@ -365,7 +365,7 @@ public:
      * @param io_service asio service associated with the connection
      * @param ssl_context asio ssl context associated with the connection
      */
-    stream(boost::asio::io_service& io_service,
+    stream(stdx::asio::io_service& io_service,
               connection::ssl_context_type& ssl_context)
         : std::basic_iostream<char, std::char_traits<char> >(NULL), m_tcp_buf(io_service, ssl_context)
     {
@@ -379,9 +379,9 @@ public:
      * @param tcp_acceptor object used to accept new connections
      * @return boost::system::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::accept()
+     * @see stdx::asio::basic_socket_acceptor::accept()
      */
-    inline boost::system::error_code accept(boost::asio::ip::tcp::acceptor& tcp_acceptor)
+    inline boost::system::error_code accept(stdx::asio::ip::tcp::acceptor& tcp_acceptor)
     {
         boost::system::error_code ec = m_tcp_buf.get_connection().accept(tcp_acceptor);
         if (! ec && get_ssl_flag()) ec = m_tcp_buf.get_connection().handshake_server();
@@ -394,9 +394,9 @@ public:
      * @param tcp_endpoint remote endpoint to connect to
      * @return boost::system::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::connect()
+     * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(boost::asio::ip::tcp::endpoint& tcp_endpoint)
+    inline boost::system::error_code connect(stdx::asio::ip::tcp::endpoint& tcp_endpoint)
     {
         boost::system::error_code ec = m_tcp_buf.get_connection().connect(tcp_endpoint);
         if (! ec && get_ssl_flag()) ec = m_tcp_buf.get_connection().handshake_client();
@@ -410,12 +410,12 @@ public:
      * @param remote_port remote port number to connect to
      * @return boost::system::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::connect()
+     * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(const boost::asio::ip::address& remote_addr,
+    inline boost::system::error_code connect(const stdx::asio::ip::address& remote_addr,
                                              const unsigned int remote_port)
     {
-        boost::asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
+        stdx::asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
         boost::system::error_code ec = m_tcp_buf.get_connection().connect(tcp_endpoint);
         if (! ec && get_ssl_flag()) ec = m_tcp_buf.get_connection().handshake_client();
         return ec;
@@ -438,7 +438,7 @@ public:
     inline bool get_ssl_flag(void) const { return m_tcp_buf.get_connection().get_ssl_flag(); }
 
     /// returns the client's IP address
-    inline boost::asio::ip::address get_remote_ip(void) const {
+    inline stdx::asio::ip::address get_remote_ip(void) const {
         return m_tcp_buf.get_connection().get_remote_ip();
     }
     

--- a/include/pion/tcp/stream.hpp
+++ b/include/pion/tcp/stream.hpp
@@ -14,10 +14,10 @@
 #include <istream>
 #include <streambuf>
 #include <boost/bind.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
+#include <pion/stdx/mutex.hpp>
+#include <pion/stdx/condition_variable.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -116,7 +116,7 @@ protected:
         const std::streamsize bytes_to_send = std::streamsize(pptr() - pbase());
         int_type bytes_sent = 0;
         if (bytes_to_send > 0) {
-            boost::mutex::scoped_lock async_lock(m_async_mutex);
+            stdx::lock_guard<stdx::mutex> async_lock(m_async_mutex);
             m_bytes_transferred = 0;
             m_conn_ptr->async_write(stdx::asio::buffer(pbase(), bytes_to_send),
                                     boost::bind(&stream_buffer::operation_finished, this,
@@ -153,7 +153,7 @@ protected:
         // read data from the TCP connection
         // note that this has to be an ansynchronous call; otherwise, it cannot
         // be cancelled by other threads and will block forever (such as during shutdown)
-        boost::mutex::scoped_lock async_lock(m_async_mutex);
+        stdx::lock_guard<stdx::mutex> async_lock(m_async_mutex);
         m_bytes_transferred = 0;
         m_conn_ptr->async_read_some(stdx::asio::buffer(m_read_buf+PUT_BACK_MAX,
                                                         connection::READ_BUFFER_SIZE-PUT_BACK_MAX),
@@ -221,7 +221,7 @@ protected:
             if ((n-bytes_available) >= (WRITE_BUFFER_SIZE-1)) {
                 // the remaining data to send is larger than the buffer available
                 // send it all now rather than buffering
-                boost::mutex::scoped_lock async_lock(m_async_mutex);
+                stdx::lock_guard<stdx::mutex> async_lock(m_async_mutex);
                 m_bytes_transferred = 0;
                 m_conn_ptr->async_write(stdx::asio::buffer(s+bytes_available,
                                                             n-bytes_available),
@@ -287,7 +287,7 @@ private:
     inline void operation_finished(const boost::system::error_code& error_code,
                                   std::size_t bytes_transferred)
     {
-        boost::mutex::scoped_lock async_lock(m_async_mutex);
+        stdx::lock_guard<stdx::mutex> async_lock(m_async_mutex);
         m_async_error = error_code;
         m_bytes_transferred = bytes_transferred;
         m_async_done.notify_one();
@@ -298,10 +298,10 @@ private:
     tcp::connection_ptr         m_conn_ptr;
     
     /// condition signaled whenever an asynchronous operation has completed
-    boost::mutex                m_async_mutex;
+    stdx::mutex                m_async_mutex;
     
     /// condition signaled whenever an asynchronous operation has completed
-    boost::condition            m_async_done;
+    stdx::condition_variable            m_async_done;
     
     /// used to keep track of the result from the last asynchronous operation
     boost::system::error_code   m_async_error;

--- a/include/pion/tcp/stream.hpp
+++ b/include/pion/tcp/stream.hpp
@@ -284,7 +284,7 @@ protected:
 private:
     
     /// function called after an asynchronous operation has completed
-    inline void operation_finished(const boost::system::error_code& error_code,
+    inline void operation_finished(const stdx::error_code& error_code,
                                   std::size_t bytes_transferred)
     {
         stdx::lock_guard<stdx::mutex> async_lock(m_async_mutex);
@@ -304,7 +304,7 @@ private:
     stdx::condition_variable            m_async_done;
     
     /// used to keep track of the result from the last asynchronous operation
-    boost::system::error_code   m_async_error;
+    stdx::error_code   m_async_error;
     
     /// the number of bytes transferred by the last asynchronous operation
     std::size_t                 m_bytes_transferred;
@@ -377,13 +377,13 @@ public:
      * accepts a new tcp connection and performs SSL handshake if necessary
      *
      * @param tcp_acceptor object used to accept new connections
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::accept()
      */
-    inline boost::system::error_code accept(stdx::asio::ip::tcp::acceptor& tcp_acceptor)
+    inline stdx::error_code accept(stdx::asio::ip::tcp::acceptor& tcp_acceptor)
     {
-        boost::system::error_code ec = m_tcp_buf.get_connection().accept(tcp_acceptor);
+        stdx::error_code ec = m_tcp_buf.get_connection().accept(tcp_acceptor);
         if (! ec && get_ssl_flag()) ec = m_tcp_buf.get_connection().handshake_server();
         return ec;
     }
@@ -392,13 +392,13 @@ public:
      * connects to a remote endpoint and performs SSL handshake if necessary
      *
      * @param tcp_endpoint remote endpoint to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(stdx::asio::ip::tcp::endpoint& tcp_endpoint)
+    inline stdx::error_code connect(stdx::asio::ip::tcp::endpoint& tcp_endpoint)
     {
-        boost::system::error_code ec = m_tcp_buf.get_connection().connect(tcp_endpoint);
+        stdx::error_code ec = m_tcp_buf.get_connection().connect(tcp_endpoint);
         if (! ec && get_ssl_flag()) ec = m_tcp_buf.get_connection().handshake_client();
         return ec;
     }
@@ -408,15 +408,15 @@ public:
      *
      * @param remote_addr remote IP address (v4) to connect to
      * @param remote_port remote port number to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return stdx::error_code contains error code if the connection fails
      *
      * @see stdx::asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(const stdx::asio::ip::address& remote_addr,
+    inline stdx::error_code connect(const stdx::asio::ip::address& remote_addr,
                                              const unsigned int remote_port)
     {
         stdx::asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
-        boost::system::error_code ec = m_tcp_buf.get_connection().connect(tcp_endpoint);
+        stdx::error_code ec = m_tcp_buf.get_connection().connect(tcp_endpoint);
         if (! ec && get_ssl_flag()) ec = m_tcp_buf.get_connection().handshake_client();
         return ec;
     }

--- a/include/pion/tcp/stream.hpp
+++ b/include/pion/tcp/stream.hpp
@@ -13,11 +13,11 @@
 #include <cstring>
 #include <istream>
 #include <streambuf>
-#include <boost/bind.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/stdx/mutex.hpp>
 #include <pion/stdx/condition_variable.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -119,7 +119,7 @@ protected:
             stdx::lock_guard<stdx::mutex> async_lock(m_async_mutex);
             m_bytes_transferred = 0;
             m_conn_ptr->async_write(stdx::asio::buffer(pbase(), bytes_to_send),
-                                    boost::bind(&stream_buffer::operation_finished, this,
+                                    stdx::bind(&stream_buffer::operation_finished, this,
                                                 stdx::asio::placeholders::error,
                                                 stdx::asio::placeholders::bytes_transferred));
             m_async_done.wait(async_lock);
@@ -157,7 +157,7 @@ protected:
         m_bytes_transferred = 0;
         m_conn_ptr->async_read_some(stdx::asio::buffer(m_read_buf+PUT_BACK_MAX,
                                                         connection::READ_BUFFER_SIZE-PUT_BACK_MAX),
-                                    boost::bind(&stream_buffer::operation_finished, this,
+                                    stdx::bind(&stream_buffer::operation_finished, this,
                                                 stdx::asio::placeholders::error,
                                                 stdx::asio::placeholders::bytes_transferred));
         m_async_done.wait(async_lock);
@@ -225,7 +225,7 @@ protected:
                 m_bytes_transferred = 0;
                 m_conn_ptr->async_write(stdx::asio::buffer(s+bytes_available,
                                                             n-bytes_available),
-                                        boost::bind(&stream_buffer::operation_finished, this,
+                                        stdx::bind(&stream_buffer::operation_finished, this,
                                                     stdx::asio::placeholders::error,
                                                     stdx::asio::placeholders::bytes_transferred));
                 m_async_done.wait(async_lock);

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_TCP_TIMER_HEADER__
 #define __PION_TCP_TIMER_HEADER__
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
@@ -18,6 +17,7 @@
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/stdx/cstdint.hpp>
+#include <pion/stdx/asio.hpp>
 
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp
@@ -62,7 +62,7 @@ private:
     tcp::connection_ptr                     m_conn_ptr;
 
     /// deadline timer used to timeout TCP operations
-    boost::asio::deadline_timer             m_timer;
+    stdx::asio::deadline_timer             m_timer;
     
     /// mutex used to synchronize the TCP connection timer
     boost::mutex                            m_mutex;

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -13,11 +13,11 @@
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/stdx/cstdint.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/mutex.hpp>
 
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp
@@ -65,7 +65,7 @@ private:
     stdx::asio::deadline_timer             m_timer;
     
     /// mutex used to synchronize the TCP connection timer
-    boost::mutex                            m_mutex;
+    stdx::mutex                            m_mutex;
 
     /// true if the deadline timer is active
     bool                                    m_timer_active; 

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -17,7 +17,7 @@
 #include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
-
+#include <pion/stdx/cstdint.hpp>
 
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp
@@ -43,7 +43,7 @@ public:
      *
      * @param seconds number of seconds before the timeout triggers
      */
-    void start(const boost::uint32_t seconds);
+    void start(const stdx::uint32_t seconds);
 
     /// cancel the timer (operation completed)
     void cancel(void);

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_TCP_TIMER_HEADER__
 #define __PION_TCP_TIMER_HEADER__
 
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
@@ -18,6 +17,7 @@
 #include <pion/stdx/cstdint.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/mutex.hpp>
+#include <pion/stdx/functional.hpp>
 
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -56,7 +56,7 @@ private:
      *
      * @param ec deadline timer error status code
      */
-    void timer_callback(const boost::system::error_code& ec);
+    void timer_callback(const stdx::error_code& ec);
 
     /// pointer to the TCP connection that is being monitored
     tcp::connection_ptr                     m_conn_ptr;

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -10,14 +10,13 @@
 #ifndef __PION_TCP_TIMER_HEADER__
 #define __PION_TCP_TIMER_HEADER__
 
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
 #include <pion/stdx/cstdint.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/mutex.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp
@@ -27,7 +26,7 @@ namespace tcp {     // begin namespace tcp
 /// timer: helper class used to time-out TCP connections
 ///
 class PION_API timer
-    : public boost::enable_shared_from_this<timer>
+    : public stdx::enable_shared_from_this<timer>
 {
 public:
 
@@ -76,7 +75,7 @@ private:
 
 
 /// shared pointer to a timer object
-typedef boost::shared_ptr<timer>     timer_ptr;
+typedef stdx::shared_ptr<timer>     timer_ptr;
 
 
 }   // end namespace tcp

--- a/include/pion/user.hpp
+++ b/include/pion/user.hpp
@@ -16,10 +16,10 @@
 #include <cstring>
 #include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
+#include <pion/stdx/mutex.hpp>
 
 #ifdef PION_HAVE_SSL
     #if defined(__APPLE__)
@@ -177,7 +177,7 @@ public:
 
     /// returns true if no users are defined
     inline bool empty(void) const {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         return m_users.empty();
     }
 
@@ -192,7 +192,7 @@ public:
     virtual bool add_user(const std::string &username,
         const std::string &password)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i!=m_users.end())
             return false;
@@ -212,7 +212,7 @@ public:
     virtual bool update_user(const std::string &username,
         const std::string &password)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i==m_users.end())
             return false;
@@ -232,7 +232,7 @@ public:
     virtual bool add_user_hash(const std::string &username,
         const std::string &password_hash)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i!=m_users.end())
             return false;
@@ -253,7 +253,7 @@ public:
     virtual bool update_user_hash(const std::string &username,
         const std::string &password_hash)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i==m_users.end())
             return false;
@@ -268,7 +268,7 @@ public:
      * @return false if no user with such username
      */
     virtual bool remove_user(const std::string &username) {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i==m_users.end())
             return false;
@@ -280,7 +280,7 @@ public:
      * Used to locate user object by username
      */
     virtual user_ptr get_user(const std::string &username) {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::const_iterator i = m_users.find(username);
         if (i==m_users.end())
             return user_ptr();
@@ -292,7 +292,7 @@ public:
      * Used to locate user object by username and password
      */
     virtual user_ptr get_user(const std::string& username, const std::string& password) {
-        boost::mutex::scoped_lock lock(m_mutex);
+        stdx::lock_guard<stdx::mutex> lock(m_mutex);
         user_map_t::const_iterator i = m_users.find(username);
         if (i==m_users.end() || !i->second->match_password(password))
             return user_ptr();
@@ -308,7 +308,7 @@ protected:
 
 
     /// mutex used to protect access to the user list
-    mutable boost::mutex    m_mutex;
+    mutable stdx::mutex    m_mutex;
 
     /// user records container
     user_map_t              m_users;

--- a/include/pion/user.hpp
+++ b/include/pion/user.hpp
@@ -14,12 +14,12 @@
 #include <string>
 #include <cstdio>
 #include <cstring>
-#include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/stdx/mutex.hpp>
+#include <pion/stdx/memory.hpp>
 
 #ifdef PION_HAVE_SSL
     #if defined(__APPLE__)
@@ -158,7 +158,7 @@ protected:
 };
 
 /// data type for a user  pointer
-typedef boost::shared_ptr<user> user_ptr;
+typedef stdx::shared_ptr<user> user_ptr;
 
 
 ///
@@ -315,7 +315,7 @@ protected:
 };
 
 /// data type for a user_manager pointer
-typedef boost::shared_ptr<user_manager>  user_manager_ptr;
+typedef stdx::shared_ptr<user_manager>  user_manager_ptr;
 
 
 }   // end namespace pion

--- a/services/AllowNothingService.cpp
+++ b/services/AllowNothingService.cpp
@@ -21,7 +21,7 @@ void AllowNothingService::operator()(const http::request_ptr& http_request_ptr, 
 {
     static const std::string DENY_HTML = "<html><body>No, you can't.</body></html>";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_METHOD_NOT_ALLOWED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_METHOD_NOT_ALLOWED);
 

--- a/services/CookieService.cpp
+++ b/services/CookieService.cpp
@@ -28,7 +28,7 @@ void CookieService::operator()(const http::request_ptr& http_request_ptr, const 
 
     // Set Content-type for HTML and write the header
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_content_type(http::types::CONTENT_TYPE_HTML);
     writer->write_no_copy(HEADER_HTML);
 

--- a/services/EchoService.cpp
+++ b/services/EchoService.cpp
@@ -8,10 +8,10 @@
 //
 
 #include "EchoService.hpp"
-#include <boost/bind.hpp>
 #include <pion/algorithm.hpp>
 #include <pion/http/response_writer.hpp>
 #include <pion/user.hpp>
+#include <pion/stdx/functional.hpp>
 
 using namespace pion;
 
@@ -46,7 +46,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     
     // Set Content-type to "text/plain" (plain ascii text)
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_content_type(http::types::CONTENT_TYPE_TEXT);
     
     // write request information
@@ -79,7 +79,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);
     std::for_each(http_request_ptr->get_headers().begin(), http_request_ptr->get_headers().end(),
-                  boost::bind(&writeDictionaryTerm, writer, _1));
+                  stdx::bind(&writeDictionaryTerm, writer, stdx::placeholders::_1));
     writer->write_no_copy(http::types::STRING_CRLF);
 
     // write query parameters
@@ -87,7 +87,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);
     std::for_each(http_request_ptr->get_queries().begin(), http_request_ptr->get_queries().end(),
-                  boost::bind(&writeDictionaryTerm, writer, _1));
+                  stdx::bind(&writeDictionaryTerm, writer, stdx::placeholders::_1));
     writer->write_no_copy(http::types::STRING_CRLF);
     
     // write cookie parameters
@@ -95,7 +95,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);
     std::for_each(http_request_ptr->get_cookies().begin(), http_request_ptr->get_cookies().end(),
-                  boost::bind(&writeDictionaryTerm, writer, _1));
+                  stdx::bind(&writeDictionaryTerm, writer, stdx::placeholders::_1));
     writer->write_no_copy(http::types::STRING_CRLF);
     
     // write POST content

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -7,7 +7,6 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/assert.hpp>
 #include <boost/lexical_cast.hpp>
@@ -21,6 +20,7 @@
 #include <pion/plugin.hpp>
 #include <pion/algorithm.hpp>
 #include <pion/http/response_writer.hpp>
+#include <pion/stdx/asio.hpp>
 
 using namespace pion;
 
@@ -918,21 +918,21 @@ void DiskFileSender::send(void)
             // send last chunk in a series
             m_writer->send_final_chunk(boost::bind(&DiskFileSender::handle_write,
                                                  shared_from_this(),
-                                                 boost::asio::placeholders::error,
-                                                 boost::asio::placeholders::bytes_transferred));
+                                                 stdx::asio::placeholders::error,
+                                                 stdx::asio::placeholders::bytes_transferred));
         } else {
             // sending entire file at once
             m_writer->send(boost::bind(&DiskFileSender::handle_write,
                                        shared_from_this(),
-                                       boost::asio::placeholders::error,
-                                       boost::asio::placeholders::bytes_transferred));
+                                       stdx::asio::placeholders::error,
+                                       stdx::asio::placeholders::bytes_transferred));
         }
     } else {
         // there will be more data -> send a chunk
         m_writer->send_chunk(boost::bind(&DiskFileSender::handle_write,
                                         shared_from_this(),
-                                        boost::asio::placeholders::error,
-                                        boost::asio::placeholders::bytes_transferred));
+                                        stdx::asio::placeholders::error,
+                                        stdx::asio::placeholders::bytes_transferred));
     }
 }
 

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -229,7 +229,7 @@ void FileService::operator()(const http::request_ptr& http_request_ptr, const tc
         if (m_cache_setting > 0 || m_scan_setting > 0) {
 
             // search for a matching cache entry
-            boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+            stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
             CacheMap::iterator cache_itr = m_cache_map.find(relative_path);
 
             if (cache_itr == m_cache_map.end()) {
@@ -366,7 +366,7 @@ void FileService::operator()(const http::request_ptr& http_request_ptr, const tc
                     // add new entry to the cache
                     PION_LOG_DEBUG(m_logger, "Adding cache entry for request ("
                                    << get_resource() << "): " << relative_path);
-                    boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+                    stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
                     m_cache_map.insert( std::make_pair(relative_path, response_file) );
                 }
             }
@@ -599,7 +599,7 @@ void FileService::start(void)
         if (m_cache_setting == 0 && m_scan_setting > 1)
             m_cache_setting = 1;
 
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
 
         // add entry for file if one is defined
         if (! m_file.empty()) {
@@ -618,7 +618,7 @@ void FileService::stop(void)
 {
     PION_LOG_DEBUG(m_logger, "Shutting down resource (" << get_resource() << ')');
     // clear cached files (if started again, it will re-scan)
-    boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+    stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
     m_cache_map.clear();
 }
 

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -936,7 +936,7 @@ void DiskFileSender::send(void)
     }
 }
 
-void DiskFileSender::handle_write(const boost::system::error_code& write_error,
+void DiskFileSender::handle_write(const stdx::error_code& write_error,
                                  std::size_t /* bytes_written */)
 {
     bool finished_sending = true;

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_FILESERVICE_HEADER__
 #define __PION_FILESERVICE_HEADER__
 
-#include <boost/shared_ptr.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/thread/once.hpp>
@@ -23,6 +22,7 @@
 #include <pion/http/response_writer.hpp>
 #include <pion/http/server.hpp>
 #include <pion/stdx/mutex.hpp>
+#include <pion/stdx/memory.hpp>
 #include <string>
 #include <map>
 
@@ -131,7 +131,7 @@ protected:
 /// DiskFileSender: class used to send files to clients using HTTP responses
 /// 
 class DiskFileSender : 
-    public boost::enable_shared_from_this<DiskFileSender>,
+    public stdx::enable_shared_from_this<DiskFileSender>,
     private boost::noncopyable
 {
 public:
@@ -143,13 +143,13 @@ public:
      * @param tcp_conn TCP connection used to send the file
      * @param max_chunk_size sets the maximum chunk size (default=0, unlimited)
      */
-    static inline boost::shared_ptr<DiskFileSender>
+    static inline stdx::shared_ptr<DiskFileSender>
         create(DiskFile& file,
                const pion::http::request_ptr& http_request_ptr,
                const pion::tcp::connection_ptr& tcp_conn,
                unsigned long max_chunk_size = 0) 
     {
-        return boost::shared_ptr<DiskFileSender>(new DiskFileSender(file, http_request_ptr,
+        return stdx::shared_ptr<DiskFileSender>(new DiskFileSender(file, http_request_ptr,
                                                                     tcp_conn, max_chunk_size));
     }
 
@@ -226,7 +226,7 @@ private:
 };
 
 /// data type for a DiskFileSender pointer
-typedef boost::shared_ptr<DiskFileSender>       DiskFileSenderPtr;
+typedef stdx::shared_ptr<DiskFileSender>       DiskFileSenderPtr;
 
 
 ///

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -14,7 +14,6 @@
 #include <boost/functional/hash.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/thread/once.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/shared_array.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
@@ -23,6 +22,7 @@
 #include <pion/http/request.hpp>
 #include <pion/http/response_writer.hpp>
 #include <pion/http/server.hpp>
+#include <pion/stdx/mutex.hpp>
 #include <string>
 #include <map>
 
@@ -353,7 +353,7 @@ private:
     CacheMap                    m_cache_map;
 
     /// mutex used to make the file cache thread-safe
-    boost::mutex                m_cache_mutex;
+    stdx::mutex                m_cache_mutex;
 
     /**
      * cache configuration setting:

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -189,7 +189,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    void handle_write(const boost::system::error_code& write_error,
+    void handle_write(const stdx::error_code& write_error,
                      std::size_t bytes_written);
 
 

--- a/services/HelloService.cpp
+++ b/services/HelloService.cpp
@@ -23,7 +23,7 @@ void HelloService::operator()(const http::request_ptr& http_request_ptr, const t
 {
     static const std::string HELLO_HTML = "<html><body>Hello World!</body></html>";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->write_no_copy(HELLO_HTML);
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);

--- a/services/LogService.cpp
+++ b/services/LogService.cpp
@@ -155,7 +155,7 @@ void LogService::operator()(const http::request_ptr& http_request_ptr, const tcp
 {
     // Set Content-type to "text/plain" (plain ascii text)
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                                   boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                                   stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_content_type(http::types::CONTENT_TYPE_TEXT);
     getLogAppender().writeLogEvents(writer);
     writer->send();

--- a/services/LogService.cpp
+++ b/services/LogService.cpp
@@ -92,7 +92,7 @@ void LogServiceAppender::_append(const log4cpp::LoggingEvent& event)
 
 void LogServiceAppender::addLogString(const std::string& log_string)
 {
-    boost::mutex::scoped_lock log_lock(m_log_mutex);
+    stdx::lock_guard<stdx::mutex> log_lock(m_log_mutex);
     m_log_events.push_back(log_string);
     ++m_num_events;
     while (m_num_events > m_max_events) {
@@ -104,7 +104,7 @@ void LogServiceAppender::addLogString(const std::string& log_string)
 void LogServiceAppender::writeLogEvents(const pion::http::response_writer_ptr& writer)
 {
 #if defined(PION_USE_LOG4CXX) || defined(PION_USE_LOG4CPLUS) || defined(PION_USE_LOG4CPP)
-    boost::mutex::scoped_lock log_lock(m_log_mutex);
+    stdx::lock_guard<stdx::mutex> log_lock(m_log_mutex);
     for (std::list<std::string>::const_iterator i = m_log_events.begin();
          i != m_log_events.end(); ++i)
     {

--- a/services/LogService.hpp
+++ b/services/LogService.hpp
@@ -10,11 +10,11 @@
 #ifndef __PION_LOGSERVICE_HEADER__
 #define __PION_LOGSERVICE_HEADER__
 
-#include <boost/thread/mutex.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <pion/logger.hpp>
 #include <pion/http/plugin_service.hpp>
 #include <pion/http/response_writer.hpp>
+#include <pion/stdx/mutex.hpp>
 #include <string>
 #include <list>
 
@@ -73,7 +73,7 @@ private:
     std::list<std::string>                  m_log_events;
 
     /// mutex to make class thread-safe
-    boost::mutex                            m_log_mutex;
+    stdx::mutex                            m_log_mutex;
 
 #if defined(PION_USE_LOG4CXX)
     public:

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -26,7 +26,7 @@ namespace pion {    // begin namespace pion
 // static members of admin_rights
 
 const stdx::int16_t    admin_rights::ADMIN_USER_ID = 0;
-boost::mutex            admin_rights::m_mutex;
+stdx::mutex            admin_rights::m_mutex;
 
 
 // admin_rights member functions

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -25,7 +25,7 @@ namespace pion {    // begin namespace pion
 
 // static members of admin_rights
 
-const boost::int16_t    admin_rights::ADMIN_USER_ID = 0;
+const stdx::int16_t    admin_rights::ADMIN_USER_ID = 0;
 boost::mutex            admin_rights::m_mutex;
 
 
@@ -121,7 +121,7 @@ long admin_rights::find_system_id(const std::string& name,
     // check if name is the system id
     const boost::regex just_numbers("\\d+");
     if (boost::regex_match(name, just_numbers)) {
-        return boost::lexical_cast<boost::int32_t>(name);
+        return boost::lexical_cast<stdx::int32_t>(name);
     }
 
     // open system file
@@ -134,7 +134,7 @@ long admin_rights::find_system_id(const std::string& name,
     typedef boost::tokenizer<boost::char_separator<char> > Tok;
     boost::char_separator<char> sep(":");
     std::string line;
-    boost::int32_t system_id = -1;
+    stdx::int32_t system_id = -1;
 
     while (std::getline(system_file, line, '\n')) {
         Tok tokens(line, sep);
@@ -145,7 +145,7 @@ long admin_rights::find_system_id(const std::string& name,
                 && boost::regex_match(*token_it, just_numbers))
             {
                 // found id as third parameter
-                system_id = boost::lexical_cast<boost::int32_t>(*token_it);
+                system_id = boost::lexical_cast<stdx::int32_t>(*token_it);
             }
             break;
         }

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -316,7 +316,7 @@ void algorithm::float_from_bytes(long double& value, const unsigned char *ptr, s
     
     // build exponent value from bitstream
     unsigned char mask = 0x80;
-    boost::int16_t exponent = 0;
+    stdx::int16_t exponent = 0;
     for (size_t n = 0; n < num_exp_bits; ++n) {
         SHIFT_BITMASK(ptr, mask);
         exponent *= 2;
@@ -353,7 +353,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     }
     
     // break down numbers >= 1.0 by incrementing the exponent & dividing by 2
-    boost::int16_t exponent = 0;
+    stdx::int16_t exponent = 0;
     while (value >= 1) {
         value /= 2;
         ++exponent;
@@ -372,7 +372,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     
     // serialize fractional value < 1.0
     bool got_exponent = false;
-    boost::uint16_t num_bits = 0;
+    stdx::uint16_t num_bits = 0;
     while (value && num_bits < num_fraction_bits) {
         value *= 2;
         if (got_exponent) {
@@ -393,7 +393,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     
     // normalize exponent.
     // note: we should have a zero exponent if value == 0
-    boost::int32_t high_bit = ::pow((long double)2, (int)(num_exp_bits - 1));
+    stdx::int32_t high_bit = ::pow((long double)2, (int)(num_exp_bits - 1));
     if (got_exponent)
         exponent += (high_bit - 1);
     else

--- a/src/http_auth.cpp
+++ b/src/http_auth.cpp
@@ -20,7 +20,7 @@ namespace http {    // begin namespace http
 
 void auth::add_restrict(const std::string& resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(http::server::strip_trailing_slash(resource));
     m_restrict_list.insert(clean_resource);
     PION_LOG_INFO(m_logger, "Set authentication restrictions for HTTP resource: " << clean_resource);
@@ -28,7 +28,7 @@ void auth::add_restrict(const std::string& resource)
 
 void auth::add_permit(const std::string& resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(http::server::strip_trailing_slash(resource));
     m_white_list.insert(clean_resource);
     PION_LOG_INFO(m_logger, "Set authentication permission for HTTP resource: " << clean_resource);
@@ -43,7 +43,7 @@ bool auth::need_authentication(const http::request_ptr& http_request_ptr) const
     // strip off trailing slash if the request has one
     std::string resource(http::server::strip_trailing_slash(http_request_ptr->get_resource()));
     
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     
     // just return false if restricted list is empty
     if (m_restrict_list.empty())

--- a/src/http_basic_auth.cpp
+++ b/src/http_basic_auth.cpp
@@ -145,7 +145,7 @@ void basic_auth::handle_unauthorized(const http::request_ptr& http_request_ptr,
         "<BODY><H1>401 Unauthorized.</H1></BODY>"
         "</HTML> ";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                                   boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                                   stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_UNAUTHORIZED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_UNAUTHORIZED);
     writer->get_response().add_header("WWW-Authenticate", "Basic realm=\"" + m_realm + "\"");

--- a/src/http_basic_auth.cpp
+++ b/src/http_basic_auth.cpp
@@ -41,7 +41,7 @@ bool basic_auth::handle_request(const http::request_ptr& http_request_ptr, const
     boost::posix_time::ptime time_now(boost::posix_time::second_clock::universal_time());
     if (time_now > m_cache_cleanup_time + boost::posix_time::seconds(CACHE_EXPIRATION)) {
         // expire cache
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
         user_cache_type::iterator i;
         user_cache_type::iterator next=m_user_cache.begin();
         while (next!=m_user_cache.end()) {
@@ -61,7 +61,7 @@ bool basic_auth::handle_request(const http::request_ptr& http_request_ptr, const
         std::string credentials;
         if (parse_authorization(authorization, credentials)) {
             // to do - use fast cache to match with active credentials
-            boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+            stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
             user_cache_type::iterator user_cache_ptr=m_user_cache.find(credentials);
             if (user_cache_ptr!=m_user_cache.end()) {
                 // we found the credentials in our cache...

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -189,7 +189,7 @@ void cookie_auth::handle_unauthorized(const http::request_ptr& http_request_ptr,
         "<BODY><H1>401 Unauthorized.</H1></BODY>"
         "</HTML> ";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-    boost::bind(&tcp::connection::finish, tcp_conn)));
+    stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_UNAUTHORIZED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_UNAUTHORIZED);
     writer->write_no_copy(CONTENT);
@@ -215,7 +215,7 @@ void cookie_auth::handle_redirection(const http::request_ptr& http_request_ptr,
         "<BODY><H1>302 Found.</H1></BODY>"
         "</HTML> ";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-        boost::bind(&tcp::connection::finish, tcp_conn)));
+        stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_FOUND);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_FOUND);
     writer->get_response().add_header(http::types::HEADER_LOCATION, redirection_url);
@@ -242,7 +242,7 @@ void cookie_auth::handle_ok(const http::request_ptr& http_request_ptr,
 {
     // send 204 (No Content) response
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-        boost::bind(&tcp::connection::finish, tcp_conn)));
+        stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_NO_CONTENT);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_NO_CONTENT);
     // Note: use empty pass "" while setting cookies to workaround IE/FF difference

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -73,7 +73,7 @@ bool cookie_auth::handle_request(const http::request_ptr& http_request_ptr, cons
     const std::string auth_cookie(http_request_ptr->get_cookie(AUTH_COOKIE_NAME));
     if (! auth_cookie.empty()) {
         // check if this cookie is in user cache
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
         user_cache_type::iterator user_cache_itr=m_user_cache.find(auth_cookie);
         if (user_cache_itr != m_user_cache.end()) {
             // we find those credential in our cache...
@@ -139,14 +139,14 @@ bool cookie_auth::process_login(const http::request_ptr& http_request_ptr, const
 
         // add new session to cache
         boost::posix_time::ptime time_now(boost::posix_time::second_clock::universal_time());
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
         m_user_cache.insert(std::make_pair(new_cookie,std::make_pair(time_now,user)));
     } else {
         // process logout sequence
         // if auth cookie presented - clean cache out
         const std::string auth_cookie(http_request_ptr->get_cookie(AUTH_COOKIE_NAME));
         if (! auth_cookie.empty()) {
-            boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+            stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
             user_cache_type::iterator user_cache_itr=m_user_cache.find(auth_cookie);
             if (user_cache_itr!=m_user_cache.end()) {
                 m_user_cache.erase(user_cache_itr);
@@ -262,7 +262,7 @@ void cookie_auth::expire_cache(const boost::posix_time::ptime &time_now)
 {
     if (time_now > m_cache_cleanup_time + boost::posix_time::seconds(CACHE_EXPIRATION)) {
         // expire cache
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        stdx::lock_guard<stdx::mutex> cache_lock(m_cache_mutex);
         user_cache_type::iterator i;
         user_cache_type::iterator next=m_user_cache.begin();
         while (next!=m_user_cache.end()) {

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -40,7 +40,7 @@ cookie_auth::cookie_auth(user_manager_ptr userManager,
     set_logger(PION_GET_LOGGER("pion.http.cookie_auth"));
 
     // Seed random number generator with current time as time_t int value, cast to the required type.
-    // (Note that boost::mt19937::result_type is boost::uint32_t, and casting to an unsigned n-bit integer is
+    // (Note that boost::mt19937::result_type is stdx::uint32_t, and casting to an unsigned n-bit integer is
     // defined by the standard to keep the lower n bits.  Since ::time() returns seconds since Jan 1, 1970, 
     // it will be a long time before we lose any entropy here, even if time_t is a 64-bit int.)
     m_random_gen.seed(static_cast<boost::mt19937::result_type>(::time(NULL)));

--- a/src/http_message.cpp
+++ b/src/http_message.cpp
@@ -31,7 +31,7 @@ const boost::regex  message::REGEX_ICASE_CHUNKED(".*chunked.*", boost::regex::ic
 // message member functions
 
 std::size_t message::send(tcp::connection& tcp_conn,
-                          boost::system::error_code& ec, bool headers_only)
+                          stdx::error_code& ec, bool headers_only)
 {
     // initialize write buffers for send operation using HTTP headers
     write_buffers_t write_buffers;
@@ -46,7 +46,7 @@ std::size_t message::send(tcp::connection& tcp_conn,
 }
 
 std::size_t message::receive(tcp::connection& tcp_conn,
-                             boost::system::error_code& ec,
+                             stdx::error_code& ec,
                              parser& http_parser)
 {
     std::size_t last_bytes_read = 0;
@@ -83,7 +83,7 @@ std::size_t message::receive(tcp::connection& tcp_conn,
             if (http_parser.check_premature_eof(*this)) {
                 // premature EOF encountered
                 if (! ec)
-                    ec = make_error_code(boost::system::errc::io_error);
+                    ec = make_error_code(stdx::errc::io_error);
                 return http_parser.get_total_bytes_read();
             } else {
                 // EOF reached when content length unknown
@@ -141,7 +141,7 @@ std::size_t message::receive(tcp::connection& tcp_conn,
 }
 
 std::size_t message::receive(tcp::connection& tcp_conn,
-                             boost::system::error_code& ec,
+                             stdx::error_code& ec,
                              bool headers_only,
                              std::size_t max_content_length)
 {
@@ -152,7 +152,7 @@ std::size_t message::receive(tcp::connection& tcp_conn,
 }
 
 std::size_t message::write(std::ostream& out,
-    boost::system::error_code& ec, bool headers_only)
+    stdx::error_code& ec, bool headers_only)
 {
     // reset error_code
     ec.clear();
@@ -172,7 +172,7 @@ std::size_t message::write(std::ostream& out,
         size_t len = stdx::asio::buffer_size(*i);
         out.write(ptr, len);
         if (!out) {
-          ec = make_error_code(boost::system::errc::io_error);
+          ec = make_error_code(stdx::errc::io_error);
           break;
         }
         bytes_out += len;
@@ -182,7 +182,7 @@ std::size_t message::write(std::ostream& out,
 }
 
 std::size_t message::read(std::istream& in,
-                          boost::system::error_code& ec,
+                          stdx::error_code& ec,
                           parser& http_parser)
 {
     // make sure that we start out with an empty message & clear error_code
@@ -195,7 +195,7 @@ std::size_t message::read(std::istream& in,
     while (in) {
         in.read(&c, 1);
         if ( ! in ) {
-            ec = make_error_code(boost::system::errc::io_error);
+            ec = make_error_code(stdx::errc::io_error);
             break;
         }
         http_parser.set_read_buffer(&c, 1);
@@ -207,7 +207,7 @@ std::size_t message::read(std::istream& in,
         if (http_parser.check_premature_eof(*this)) {
             // premature EOF encountered
             if (! ec)
-                ec = make_error_code(boost::system::errc::io_error);
+                ec = make_error_code(stdx::errc::io_error);
         } else {
             // EOF reached when content length unknown
             // assume it is the correct end of content
@@ -221,7 +221,7 @@ std::size_t message::read(std::istream& in,
 }
 
 std::size_t message::read(std::istream& in,
-                          boost::system::error_code& ec,
+                          stdx::error_code& ec,
                           bool headers_only,
                           std::size_t max_content_length)
 {

--- a/src/http_message.cpp
+++ b/src/http_message.cpp
@@ -9,7 +9,6 @@
 
 #include <iostream>
 #include <algorithm>
-#include <boost/asio.hpp>
 #include <boost/assert.hpp>
 #include <boost/regex.hpp>
 #include <boost/logic/tribool.hpp>
@@ -17,6 +16,7 @@
 #include <pion/http/request.hpp>
 #include <pion/http/parser.hpp>
 #include <pion/tcp/connection.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -39,7 +39,7 @@ std::size_t message::send(tcp::connection& tcp_conn,
 
     // append payload content to write buffers (if there is any)
     if (!headers_only && get_content_length() > 0 && get_content() != NULL)
-        write_buffers.push_back(boost::asio::buffer(get_content(), get_content_length()));
+        write_buffers.push_back(stdx::asio::buffer(get_content(), get_content_length()));
 
     // send the message and return the result
     return tcp_conn.write(write_buffers, ec);
@@ -163,13 +163,13 @@ std::size_t message::write(std::ostream& out,
 
     // append payload content to write buffers (if there is any)
     if (!headers_only && get_content_length() > 0 && get_content() != NULL)
-        write_buffers.push_back(boost::asio::buffer(get_content(), get_content_length()));
+        write_buffers.push_back(stdx::asio::buffer(get_content(), get_content_length()));
 
     // write message to the output stream
     std::size_t bytes_out = 0;
     for (write_buffers_t::const_iterator i=write_buffers.begin(); i!=write_buffers.end(); ++i) {
-        const char *ptr = boost::asio::buffer_cast<const char*>(*i);
-        size_t len = boost::asio::buffer_size(*i);
+        const char *ptr = stdx::asio::buffer_cast<const char*>(*i);
+        size_t len = stdx::asio::buffer_size(*i);
         out.write(ptr, len);
         if (!out) {
           ec = make_error_code(boost::system::errc::io_error);

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -26,16 +26,16 @@ namespace http {    // begin namespace http
 
 // static members of parser
 
-const boost::uint32_t   parser::STATUS_MESSAGE_MAX = 1024;  // 1 KB
-const boost::uint32_t   parser::METHOD_MAX = 1024;  // 1 KB
-const boost::uint32_t   parser::RESOURCE_MAX = 256 * 1024;  // 256 KB
-const boost::uint32_t   parser::QUERY_STRING_MAX = 1024 * 1024; // 1 MB
-const boost::uint32_t   parser::HEADER_NAME_MAX = 1024; // 1 KB
-const boost::uint32_t   parser::HEADER_VALUE_MAX = 1024 * 1024; // 1 MB
-const boost::uint32_t   parser::QUERY_NAME_MAX = 1024;  // 1 KB
-const boost::uint32_t   parser::QUERY_VALUE_MAX = 1024 * 1024;  // 1 MB
-const boost::uint32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
-const boost::uint32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
+const stdx::uint32_t   parser::STATUS_MESSAGE_MAX = 1024;  // 1 KB
+const stdx::uint32_t   parser::METHOD_MAX = 1024;  // 1 KB
+const stdx::uint32_t   parser::RESOURCE_MAX = 256 * 1024;  // 256 KB
+const stdx::uint32_t   parser::QUERY_STRING_MAX = 1024 * 1024; // 1 MB
+const stdx::uint32_t   parser::HEADER_NAME_MAX = 1024; // 1 KB
+const stdx::uint32_t   parser::HEADER_VALUE_MAX = 1024 * 1024; // 1 MB
+const stdx::uint32_t   parser::QUERY_NAME_MAX = 1024;  // 1 KB
+const stdx::uint32_t   parser::QUERY_VALUE_MAX = 1024 * 1024;  // 1 MB
+const stdx::uint32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
+const stdx::uint32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
 const std::size_t       parser::DEFAULT_CONTENT_MAX = 1024 * 1024;  // 1 MB
 parser::error_category_t * parser::m_error_category_ptr = NULL;
 boost::once_flag            parser::m_instance_flag = BOOST_ONCE_INIT;
@@ -828,7 +828,7 @@ boost::tribool parser::finish_header_parsing(http::message& http_msg,
 }
     
 bool parser::parse_uri(const std::string& uri, std::string& proto, 
-                      std::string& host, boost::uint16_t& port,
+                      std::string& host, stdx::uint16_t& port,
                       std::string& path, std::string& query)
 {
     size_t proto_end = uri.find("://");

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -44,7 +44,7 @@ boost::once_flag            parser::m_instance_flag = BOOST_ONCE_INIT;
 // parser member functions
 
 boost::tribool parser::parse(http::message& http_msg,
-    boost::system::error_code& ec)
+    stdx::error_code& ec)
 {
     BOOST_ASSERT(! eof() );
 
@@ -123,7 +123,7 @@ boost::tribool parser::parse(http::message& http_msg,
 }
 
 boost::tribool parser::parse_missing_data(http::message& http_msg,
-    std::size_t len, boost::system::error_code& ec)
+    std::size_t len, stdx::error_code& ec)
 {
     static const char MISSING_DATA_CHAR = 'X';
     boost::tribool rc = boost::indeterminate;
@@ -237,7 +237,7 @@ boost::tribool parser::parse_missing_data(http::message& http_msg,
 }
 
 boost::tribool parser::parse_headers(http::message& http_msg,
-    boost::system::error_code& ec)
+    stdx::error_code& ec)
 {
     //
     // note that boost::tribool may have one of THREE states:
@@ -741,7 +741,7 @@ void parser::update_message_with_header_data(http::message& http_msg) const
 }
 
 boost::tribool parser::finish_header_parsing(http::message& http_msg,
-    boost::system::error_code& ec)
+    stdx::error_code& ec)
 {
     boost::tribool rc = boost::indeterminate;
 
@@ -1256,7 +1256,7 @@ bool parser::parse_cookie_header(ihash_multimap& dict,
 }
 
 boost::tribool parser::parse_chunks(http::message::chunk_cache_t& chunks,
-    boost::system::error_code& ec)
+    stdx::error_code& ec)
 {
     //
     // note that boost::tribool may have one of THREE states:
@@ -1422,7 +1422,7 @@ boost::tribool parser::parse_chunks(http::message::chunk_cache_t& chunks,
 }
 
 boost::tribool parser::consume_content(http::message& http_msg,
-    boost::system::error_code& /* ec */)
+    stdx::error_code& /* ec */)
 {
     size_t content_bytes_to_read;
     size_t content_bytes_available = bytes_available();

--- a/src/http_plugin_server.cpp
+++ b/src/http_plugin_server.cpp
@@ -28,7 +28,7 @@ void plugin_server::add_service(const std::string& resource, http::plugin_servic
     const std::string clean_resource(strip_trailing_slash(resource));
     service_ptr->set_resource(clean_resource);
     m_services.add(clean_resource, service_ptr);
-    http::server::add_resource(clean_resource, boost::ref(*service_ptr));
+    http::server::add_resource(clean_resource, stdx::ref(*service_ptr));
     PION_LOG_INFO(m_logger, "Loaded static web service for resource (" << clean_resource << ")");
 }
 
@@ -37,7 +37,7 @@ void plugin_server::load_service(const std::string& resource, const std::string&
     const std::string clean_resource(strip_trailing_slash(resource));
     http::plugin_service *service_ptr;
     service_ptr = m_services.load(clean_resource, service_name);
-    http::server::add_resource(clean_resource, boost::ref(*service_ptr));
+    http::server::add_resource(clean_resource, stdx::ref(*service_ptr));
     service_ptr->set_resource(clean_resource);
     PION_LOG_INFO(m_logger, "Loaded web service plug-in for resource (" << clean_resource << "): " << service_name);
 }
@@ -46,7 +46,7 @@ void plugin_server::set_service_option(const std::string& resource,
                                  const std::string& name, const std::string& value)
 {
     const std::string clean_resource(strip_trailing_slash(resource));
-    m_services.run(clean_resource, boost::bind(&http::plugin_service::set_option, _1, name, value));
+    m_services.run(clean_resource, stdx::bind(&http::plugin_service::set_option, stdx::placeholders::_1, name, value));
     PION_LOG_INFO(m_logger, "Set web service option for resource ("
                   << resource << "): " << name << '=' << value);
 }

--- a/src/http_reader.cpp
+++ b/src/http_reader.cpp
@@ -7,10 +7,10 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
 #include <boost/logic/tribool.hpp>
 #include <pion/http/reader.hpp>
 #include <pion/http/request.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -145,7 +145,7 @@ void reader::handle_read_error(const boost::system::error_code& read_error)
     
     // only log errors if the parsing has already begun
     if (get_total_bytes_read() > 0) {
-        if (read_error == boost::asio::error::operation_aborted) {
+        if (read_error == stdx::asio::error::operation_aborted) {
             // if the operation was aborted, the acceptor was stopped,
             // which means another thread is shutting-down the server
             PION_LOG_INFO(m_logger, "HTTP " << (is_parsing_request() ? "request" : "response")

--- a/src/http_reader.cpp
+++ b/src/http_reader.cpp
@@ -38,7 +38,7 @@ void reader::receive(void)
     }
 }
 
-void reader::consume_bytes(const boost::system::error_code& read_error,
+void reader::consume_bytes(const stdx::error_code& read_error,
                               std::size_t bytes_read)
 {
     // cancel read timer if operation didn't time-out
@@ -73,7 +73,7 @@ void reader::consume_bytes(void)
     // true: finished successfully parsing the message
     // indeterminate: parsed bytes, but the message is not yet finished
     //
-    boost::system::error_code ec;
+    stdx::error_code ec;
     boost::tribool result = parse(get_message(), ec);
     
     if (gcount() > 0) {
@@ -131,14 +131,14 @@ void reader::read_bytes_with_timeout(void)
     read_bytes();
 }
 
-void reader::handle_read_error(const boost::system::error_code& read_error)
+void reader::handle_read_error(const stdx::error_code& read_error)
 {
     // close the connection, forcing the client to establish a new one
     m_tcp_conn->set_lifecycle(tcp::connection::LIFECYCLE_CLOSE);   // make sure it will get closed
 
     // check if this is just a message with unknown content length
     if (! check_premature_eof(get_message())) {
-        boost::system::error_code ec;   // clear error code
+        stdx::error_code ec;   // clear error code
         finished_reading(ec);
         return;
     }

--- a/src/http_reader.cpp
+++ b/src/http_reader.cpp
@@ -19,7 +19,7 @@ namespace http {    // begin namespace http
 
 // reader static members
     
-const boost::uint32_t       reader::DEFAULT_READ_TIMEOUT = 10;
+const stdx::uint32_t       reader::DEFAULT_READ_TIMEOUT = 10;
 
 
 // reader member functions

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -47,7 +47,7 @@ void server::handle_request(const http::request_ptr& http_request_ptr,
         } else {
             static const boost::system::error_condition
                     ERRCOND_CANCELED(boost::system::errc::operation_canceled, boost::system::system_category()),
-                    ERRCOND_EOF(boost::asio::error::eof, boost::asio::error::misc_category);
+                    ERRCOND_EOF(stdx::asio::error::eof, stdx::asio::error::misc_category);
 
             if (ec == ERRCOND_CANCELED || ec == ERRCOND_EOF) {
                 // don't spam the log with common (non-)errors that happen during normal operation

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -135,7 +135,7 @@ bool server::find_request_handler(const std::string& resource,
                                     request_handler_t& request_handler) const
 {
     // first make sure that HTTP resources are registered
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     if (m_resources.empty())
         return false;
     
@@ -160,7 +160,7 @@ bool server::find_request_handler(const std::string& resource,
 void server::add_resource(const std::string& resource,
                              request_handler_t request_handler)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(strip_trailing_slash(resource));
     m_resources.insert(std::make_pair(clean_resource, request_handler));
     PION_LOG_INFO(m_logger, "Added request handler for HTTP resource: " << clean_resource);
@@ -168,7 +168,7 @@ void server::add_resource(const std::string& resource,
 
 void server::remove_resource(const std::string& resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(strip_trailing_slash(resource));
     m_resources.erase(clean_resource);
     PION_LOG_INFO(m_logger, "Removed request handler for HTTP resource: " << clean_resource);
@@ -177,7 +177,7 @@ void server::remove_resource(const std::string& resource)
 void server::add_redirect(const std::string& requested_resource,
                              const std::string& new_resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    stdx::lock_guard<stdx::mutex> resource_lock(m_resource_mutex);
     const std::string clean_requested_resource(strip_trailing_slash(requested_resource));
     const std::string clean_new_resource(strip_trailing_slash(new_resource));
     m_redirects.insert(std::make_pair(clean_requested_resource, clean_new_resource));

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -29,8 +29,8 @@ const unsigned int          server::MAX_REDIRECTS = 10;
 void server::handle_connection(const tcp::connection_ptr& tcp_conn)
 {
     request_reader_ptr my_reader_ptr;
-    my_reader_ptr = request_reader::create(tcp_conn, boost::bind(&server::handle_request,
-                                           this, _1, _2, _3));
+    my_reader_ptr = request_reader::create(tcp_conn, stdx::bind(&server::handle_request,
+                                           this, stdx::placeholders::_1, stdx::placeholders::_2, stdx::placeholders::_3));
     my_reader_ptr->set_max_content_length(m_max_content_length);
     my_reader_ptr->receive();
 }
@@ -195,7 +195,7 @@ void server::handle_bad_request(const http::request_ptr& http_request_ptr,
         "<p>Your browser sent a request that this server could not understand.</p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_BAD_REQUEST);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_BAD_REQUEST);
     writer->write_no_copy(BAD_REQUEST_HTML);
@@ -215,7 +215,7 @@ void server::handle_not_found_request(const http::request_ptr& http_request_ptr,
         " was not found on this server.</p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_NOT_FOUND);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_NOT_FOUND);
     writer->write_no_copy(NOT_FOUND_HTML_START);
@@ -238,7 +238,7 @@ void server::handle_server_error(const http::request_ptr& http_request_ptr,
         "</strong></p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_SERVER_ERROR);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_SERVER_ERROR);
     writer->write_no_copy(SERVER_ERROR_HTML_START);
@@ -263,7 +263,7 @@ void server::handle_forbidden_request(const http::request_ptr& http_request_ptr,
         "</strong></p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_FORBIDDEN);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_FORBIDDEN);
     writer->write_no_copy(FORBIDDEN_HTML_START);
@@ -288,7 +288,7 @@ void server::handle_method_not_allowed(const http::request_ptr& http_request_ptr
         " is not allowed on this server.</p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            stdx::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_METHOD_NOT_ALLOWED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_METHOD_NOT_ALLOWED);
     if (! allowed_methods.empty())

--- a/src/http_types.cpp
+++ b/src/http_types.cpp
@@ -8,9 +8,9 @@
 //
 
 #include <boost/lexical_cast.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/http/types.hpp>
 #include <pion/algorithm.hpp>
+#include <pion/stdx/mutex.hpp>
 #include <cstdio>
 #include <ctime>
 
@@ -98,12 +98,12 @@ const unsigned int  types::RESPONSE_CODE_CONTINUE = 100;
 std::string types::get_date_string(const time_t t)
 {
     // use mutex since time functions are normally not thread-safe
-    static boost::mutex time_mutex;
+    static stdx::mutex time_mutex;
     static const char *TIME_FORMAT = "%a, %d %b %Y %H:%M:%S GMT";
     static const unsigned int TIME_BUF_SIZE = 100;
     char time_buf[TIME_BUF_SIZE+1];
 
-    boost::mutex::scoped_lock time_lock(time_mutex);
+    stdx::unique_lock<stdx::mutex> time_lock(time_mutex);
     if (strftime(time_buf, TIME_BUF_SIZE, TIME_FORMAT, gmtime(&t)) == 0)
         time_buf[0] = '\0'; // failed; resulting buffer is indeterminate
     time_lock.unlock();

--- a/src/http_writer.cpp
+++ b/src/http_writer.cpp
@@ -7,9 +7,9 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/message.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -45,15 +45,15 @@ void writer::prepare_write_buffers(http::message::write_buffers_t& write_buffers
             // add chunk length as a string at the back of the text cache
             m_text_cache.push_back(cast_buf);
             // append length of chunk to write_buffers
-            write_buffers.push_back(boost::asio::buffer(m_text_cache.back()));
+            write_buffers.push_back(stdx::asio::buffer(m_text_cache.back()));
             // append an extra CRLF for chunk formatting
-            write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
+            write_buffers.push_back(stdx::asio::buffer(http::types::STRING_CRLF));
             
             // append response content buffers
             write_buffers.insert(write_buffers.end(), m_content_buffers.begin(),
                                  m_content_buffers.end());
             // append an extra CRLF for chunk formatting
-            write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
+            write_buffers.push_back(stdx::asio::buffer(http::types::STRING_CRLF));
         } else {
             // append response content buffers
             write_buffers.insert(write_buffers.end(), m_content_buffers.begin(),
@@ -66,10 +66,10 @@ void writer::prepare_write_buffers(http::message::write_buffers_t& write_buffers
         // add chunk length as a string at the back of the text cache
         m_text_cache.push_back("0");
         // append length of chunk to write_buffers
-        write_buffers.push_back(boost::asio::buffer(m_text_cache.back()));
+        write_buffers.push_back(stdx::asio::buffer(m_text_cache.back()));
         // append an extra CRLF for chunk formatting
-        write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
-        write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
+        write_buffers.push_back(stdx::asio::buffer(http::types::STRING_CRLF));
+        write_buffers.push_back(stdx::asio::buffer(http::types::STRING_CRLF));
     }
 }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -34,7 +34,7 @@ process::config_type *process::m_config_ptr = NULL;
 void process::shutdown(void)
 {
     config_type& cfg = get_config();
-    boost::mutex::scoped_lock shutdown_lock(cfg.shutdown_mutex);
+    stdx::lock_guard<stdx::mutex> shutdown_lock(cfg.shutdown_mutex);
     if (! cfg.shutdown_now) {
         cfg.shutdown_now = true;
         cfg.shutdown_cond.notify_all();
@@ -44,7 +44,7 @@ void process::shutdown(void)
 void process::wait_for_shutdown(void)
 {
     config_type& cfg = get_config();
-    boost::mutex::scoped_lock shutdown_lock(cfg.shutdown_mutex);
+    stdx::unique_lock<stdx::mutex> shutdown_lock(cfg.shutdown_mutex);
     while (! cfg.shutdown_now)
         cfg.shutdown_cond.wait(shutdown_lock);
 }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -16,10 +16,10 @@ namespace pion {    // begin namespace pion
 
 // static members of scheduler
     
-const boost::uint32_t   scheduler::DEFAULT_NUM_THREADS = 8;
-const boost::uint32_t   scheduler::NSEC_IN_SECOND = 1000000000; // (10^9)
-const boost::uint32_t   scheduler::MICROSEC_IN_SECOND = 1000000;    // (10^6)
-const boost::uint32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
+const stdx::uint32_t   scheduler::DEFAULT_NUM_THREADS = 8;
+const stdx::uint32_t   scheduler::NSEC_IN_SECOND = 1000000000; // (10^9)
+const stdx::uint32_t   scheduler::MICROSEC_IN_SECOND = 1000000;    // (10^6)
+const stdx::uint32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
 
 
 // scheduler member functions
@@ -99,8 +99,8 @@ void scheduler::remove_active_user(void)
         m_no_more_active_users.notify_all();
 }
 
-boost::system_time scheduler::get_wakeup_time(boost::uint32_t sleep_sec,
-    boost::uint32_t sleep_nsec)
+boost::system_time scheduler::get_wakeup_time(stdx::uint32_t sleep_sec,
+    stdx::uint32_t sleep_nsec)
 {
     return boost::get_system_time() + boost::posix_time::seconds(sleep_sec) + boost::posix_time::microseconds(sleep_nsec / 1000);
 }
@@ -134,7 +134,7 @@ void single_service_scheduler::startup(void)
         keep_running(m_service, m_timer);
         
         // start multiple threads to handle async tasks
-        for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
+        for (stdx::uint32_t n = 0; n < m_num_threads; ++n) {
             boost::shared_ptr<boost::thread> new_thread(new boost::thread( boost::bind(&scheduler::process_service_work,
                                                                                        this, boost::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
@@ -166,7 +166,7 @@ void one_to_one_scheduler::startup(void)
         }
         
         // start multiple threads to handle async tasks
-        for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
+        for (stdx::uint32_t n = 0; n < m_num_threads; ++n) {
             boost::shared_ptr<boost::thread> new_thread(new boost::thread( boost::bind(&scheduler::process_service_work,
                                                                                        this, boost::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -80,8 +80,8 @@ void scheduler::keep_running(stdx::asio::io_service& my_service,
     if (m_is_running) {
         // schedule this again to make sure the service doesn't complete
         my_timer.expires_from_now(boost::posix_time::seconds(KEEP_RUNNING_TIMER_SECONDS));
-        my_timer.async_wait(boost::bind(&scheduler::keep_running, this,
-                                        boost::ref(my_service), boost::ref(my_timer)));
+        my_timer.async_wait(stdx::bind(&scheduler::keep_running, this,
+                                        stdx::ref(my_service), stdx::ref(my_timer)));
     }
 }
 
@@ -135,8 +135,8 @@ void single_service_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (stdx::uint32_t n = 0; n < m_num_threads; ++n) {
-            boost::shared_ptr<stdx::thread> new_thread(new stdx::thread( boost::bind(&scheduler::process_service_work,
-                                                                                       this, boost::ref(m_service)) ));
+            boost::shared_ptr<stdx::thread> new_thread(new stdx::thread( stdx::bind(&scheduler::process_service_work,
+                                                                                       this, stdx::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
         }
     }
@@ -167,8 +167,8 @@ void one_to_one_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (stdx::uint32_t n = 0; n < m_num_threads; ++n) {
-            boost::shared_ptr<stdx::thread> new_thread(new stdx::thread( boost::bind(&scheduler::process_service_work,
-                                                                                       this, boost::ref(m_service_pool[n]->first)) ));
+            boost::shared_ptr<stdx::thread> new_thread(new stdx::thread( stdx::bind(&scheduler::process_service_work,
+                                                                                       this, stdx::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);
         }
     }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -74,8 +74,8 @@ void scheduler::join(void)
     }
 }
     
-void scheduler::keep_running(boost::asio::io_service& my_service,
-                                boost::asio::deadline_timer& my_timer)
+void scheduler::keep_running(stdx::asio::io_service& my_service,
+                                stdx::asio::deadline_timer& my_timer)
 {
     if (m_is_running) {
         // schedule this again to make sure the service doesn't complete
@@ -105,7 +105,7 @@ boost::system_time scheduler::get_wakeup_time(stdx::uint32_t sleep_sec,
     return boost::get_system_time() + boost::posix_time::seconds(sleep_sec) + boost::posix_time::microseconds(sleep_nsec / 1000);
 }
                      
-void scheduler::process_service_work(boost::asio::io_service& service) {
+void scheduler::process_service_work(stdx::asio::io_service& service) {
     while (m_is_running) {
         try {
             service.run();

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -135,7 +135,7 @@ void single_service_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (stdx::uint32_t n = 0; n < m_num_threads; ++n) {
-            boost::shared_ptr<stdx::thread> new_thread(new stdx::thread( stdx::bind(&scheduler::process_service_work,
+            stdx::shared_ptr<stdx::thread> new_thread(new stdx::thread( stdx::bind(&scheduler::process_service_work,
                                                                                        this, stdx::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
         }
@@ -156,7 +156,7 @@ void one_to_one_scheduler::startup(void)
         
         // make sure there are enough services initialized
         while (m_service_pool.size() < m_num_threads) {
-            boost::shared_ptr<service_pair_type>  service_ptr(new service_pair_type());
+            stdx::shared_ptr<service_pair_type>  service_ptr(new service_pair_type());
             m_service_pool.push_back(service_ptr);
         }
 
@@ -167,7 +167,7 @@ void one_to_one_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (stdx::uint32_t n = 0; n < m_num_threads; ++n) {
-            boost::shared_ptr<stdx::thread> new_thread(new stdx::thread( stdx::bind(&scheduler::process_service_work,
+            stdx::shared_ptr<stdx::thread> new_thread(new stdx::thread( stdx::bind(&scheduler::process_service_work,
                                                                                        this, stdx::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);
         }

--- a/src/spdy_decompressor.cpp
+++ b/src/spdy_decompressor.cpp
@@ -87,9 +87,9 @@ decompressor::~decompressor()
 }
 
 char* decompressor::decompress(const char *compressed_data_ptr,
-                               boost::uint32_t stream_id,
+                               stdx::uint32_t stream_id,
                                const spdy_control_frame_info& frame,
-                               boost::uint32_t header_block_length)
+                               stdx::uint32_t header_block_length)
 {
     /// Get our decompressor.
     z_streamp decomp = NULL;
@@ -113,7 +113,7 @@ char* decompressor::decompress(const char *compressed_data_ptr,
     BOOST_ASSERT(decomp);
     
     // Decompress the data
-    boost::uint32_t uncomp_length = 0;
+    stdx::uint32_t uncomp_length = 0;
     
     // Catch decompression failures.
     if (!spdy_decompress_header(compressed_data_ptr, decomp,
@@ -130,10 +130,10 @@ char* decompressor::decompress(const char *compressed_data_ptr,
 
 bool decompressor::spdy_decompress_header(const char *compressed_data_ptr,
                                           z_streamp decomp,
-                                          boost::uint32_t length,
-                                          boost::uint32_t& uncomp_length) {
+                                          stdx::uint32_t length,
+                                          stdx::uint32_t& uncomp_length) {
     int retcode;
-    const boost::uint8_t *hptr = (boost::uint8_t *)compressed_data_ptr;
+    const stdx::uint8_t *hptr = (stdx::uint8_t *)compressed_data_ptr;
     
     decomp->next_in = (Bytef *)hptr;
     decomp->avail_in = length;

--- a/src/spdy_decompressor.cpp
+++ b/src/spdy_decompressor.cpp
@@ -11,6 +11,7 @@
 #include <zlib.h>
 #include <iostream>
 #include <fstream>
+#include <boost/assert.hpp>
 #include <pion/spdy/decompressor.hpp>
 
 

--- a/src/spdy_decompressor.cpp
+++ b/src/spdy_decompressor.cpp
@@ -11,7 +11,6 @@
 #include <zlib.h>
 #include <iostream>
 #include <fstream>
-#include <boost/asio/detail/socket_ops.hpp>
 #include <pion/spdy/decompressor.hpp>
 
 

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -21,7 +21,7 @@ namespace pion {    // begin namespace pion
 namespace spdy {    // begin namespace spdy
 
 /// RST stream status string from code, return NULL for unknown status code
-static char const* rst_stream_status(boost::uint32_t rst_stream_status_code)
+static char const* rst_stream_status(stdx::uint32_t rst_stream_status_code)
 {
     switch (rst_stream_status_code)
     {
@@ -58,8 +58,8 @@ boost::tribool parser::parse(http_protocol_info& http_info,
                              boost::system::error_code& ec,
                              const decompressor_ptr& decompressor,
                              const char *packet_ptr,
-                             boost::uint32_t& length_packet,
-                             boost::uint32_t current_stream_count)
+                             stdx::uint32_t& length_packet,
+                             stdx::uint32_t current_stream_count)
 {
     // initialize read position
     set_read_ptr(packet_ptr);
@@ -73,9 +73,9 @@ bool parser::is_spdy_control_frame(const char *ptr)
     // Parse further for higher accuracy
     
     // Get the control bit
-    boost::uint8_t control_bit;
-    boost::uint16_t version, type;
-    boost::uint16_t byte_value = algorithm::to_uint16(ptr);
+    stdx::uint8_t control_bit;
+    stdx::uint16_t version, type;
+    stdx::uint16_t byte_value = algorithm::to_uint16(ptr);
     control_bit = byte_value >> (sizeof(short) * CHAR_BIT - 1);
 
     if (!control_bit) return false;
@@ -83,7 +83,7 @@ bool parser::is_spdy_control_frame(const char *ptr)
     // Control bit is set; This is a control frame
     
     // Get the version number
-    boost::uint16_t two_bytes = algorithm::to_uint16(ptr);
+    stdx::uint16_t two_bytes = algorithm::to_uint16(ptr);
     version = two_bytes & 0x7FFF;
     
     if(version < 1 || version > 3){
@@ -119,7 +119,7 @@ spdy_frame_type parser::get_spdy_frame_type(const char *ptr)
      */
     
     spdy_frame_type spdy_frame;
-    boost::uint8_t first_byte = *((unsigned char *)ptr);
+    stdx::uint8_t first_byte = *((unsigned char *)ptr);
     if(first_byte == 0x80){
         spdy_frame = spdy_control_frame;
     }else if(first_byte == 0x0){
@@ -130,27 +130,27 @@ spdy_frame_type parser::get_spdy_frame_type(const char *ptr)
     return spdy_frame;
 }
     
-boost::uint32_t parser::get_control_frame_stream_id(const char *ptr)
+stdx::uint32_t parser::get_control_frame_stream_id(const char *ptr)
 {
     // The stream ID for control frames is at a 8 bit offser from start
     ptr += 8;
 
-    boost::uint32_t four_bytes = algorithm::to_uint32(ptr);
+    stdx::uint32_t four_bytes = algorithm::to_uint32(ptr);
     return four_bytes & 0x7FFFFFFF;
 }
     
 boost::tribool parser::parse_spdy_frame(boost::system::error_code& ec,
                                         const decompressor_ptr& decompressor,
                                         http_protocol_info& http_info,
-                                        boost::uint32_t& length_packet,
-                                        boost::uint32_t current_stream_count)
+                                        stdx::uint32_t& length_packet,
+                                        stdx::uint32_t current_stream_count)
 {
     boost::tribool rc = true;
     
     // Verify that this is a spdy frame
     
     BOOST_ASSERT(m_read_ptr);
-    boost::uint8_t first_byte = (boost::uint8_t)*m_read_ptr;
+    stdx::uint8_t first_byte = (stdx::uint8_t)*m_read_ptr;
     if (first_byte != 0x80 && first_byte != 0x0) {
         // This is not a SPDY frame, throw an error
         PION_LOG_ERROR(m_logger, "Invalid SPDY Frame");
@@ -158,9 +158,9 @@ boost::tribool parser::parse_spdy_frame(boost::system::error_code& ec,
         return false;
     }
     
-    boost::uint8_t              control_bit;
+    stdx::uint8_t              control_bit;
     spdy_control_frame_info     frame;
-    boost::uint32_t             stream_id = 0;
+    stdx::uint32_t             stream_id = 0;
     
     ec.clear();
 
@@ -174,7 +174,7 @@ boost::tribool parser::parse_spdy_frame(boost::system::error_code& ec,
     
     BOOST_ASSERT(stream_id != 0);
     
-    control_bit = (boost::uint8_t)frame.control_bit;
+    control_bit = (stdx::uint8_t)frame.control_bit;
     
     // There is a possibility that there are more than one SPDY frames in one TCP frame
     if(length_packet > frame.length){
@@ -263,13 +263,13 @@ void parser::create_error_category(void)
 
 bool parser::populate_frame(boost::system::error_code& ec,
                             spdy_control_frame_info& frame,
-                            boost::uint32_t& length_packet,
-                            boost::uint32_t& stream_id,
+                            stdx::uint32_t& length_packet,
+                            stdx::uint32_t& stream_id,
                             http_protocol_info& http_info)
 {
     // Get the control bit
-    boost::uint8_t control_bit;
-    boost::uint16_t byte_value = algorithm::to_uint16(m_read_ptr);
+    stdx::uint8_t control_bit;
+    stdx::uint16_t byte_value = algorithm::to_uint16(m_read_ptr);
     control_bit = byte_value >> (sizeof(short) * CHAR_BIT - 1);
     
     frame.control_bit = (control_bit != 0);
@@ -279,7 +279,7 @@ bool parser::populate_frame(boost::system::error_code& ec,
         // Control bit is set; This is a control frame
         
         // Get the version number
-        boost::uint16_t two_bytes = algorithm::to_uint16(m_read_ptr);
+        stdx::uint16_t two_bytes = algorithm::to_uint16(m_read_ptr);
         frame.version = two_bytes & 0x7FFF;
         
         // Increment the read pointer
@@ -305,7 +305,7 @@ bool parser::populate_frame(boost::system::error_code& ec,
         frame.type = SPDY_DATA;
         frame.version = 0; /* Version doesn't apply to DATA. */
         // Get the stream id
-        boost::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+        stdx::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
         stream_id = four_bytes & 0x7FFFFFFF;
         
         http_info.stream_id = stream_id;
@@ -322,12 +322,12 @@ bool parser::populate_frame(boost::system::error_code& ec,
     http_info.data_offset +=2;
     
     // Get the flags
-    frame.flags = (boost::uint8_t)*m_read_ptr;
+    frame.flags = (stdx::uint8_t)*m_read_ptr;
     
     // Increment the read pointer
     
     // Get the length
-    boost::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+    stdx::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
     frame.length = four_bytes & 0xFFFFFF;
     
     // Increment the read pointer
@@ -349,14 +349,14 @@ void parser::parse_header_payload(boost::system::error_code &ec,
                                   const decompressor_ptr& decompressor,
                                   const spdy_control_frame_info& frame,
                                   http_protocol_info& http_info,
-                                  boost::uint32_t /* current_stream_count */)
+                                  stdx::uint32_t /* current_stream_count */)
 {
-    boost::uint32_t stream_id = 0;
-    boost::uint32_t header_block_length = frame.length;
+    stdx::uint32_t stream_id = 0;
+    stdx::uint32_t header_block_length = frame.length;
     
     // Get the 31 bit stream id
     
-    boost::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+    stdx::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
     stream_id = four_bytes & 0x7FFFFFFF;
     
     m_read_ptr += 4;
@@ -417,37 +417,37 @@ void parser::parse_header_payload(boost::system::error_code &ec,
     // and it is 32 bit in SPDYv3
     
     // TBD : Add support for SPDYv3
-    boost::uint16_t num_name_val_pairs = algorithm::to_uint16(m_uncompressed_ptr);
+    stdx::uint16_t num_name_val_pairs = algorithm::to_uint16(m_uncompressed_ptr);
     
     m_uncompressed_ptr += 2;
     
     std::string content_type = "";
     std::string content_encoding = "";
     
-    for(boost::uint16_t count = 0; count < num_name_val_pairs; ++count){
+    for(stdx::uint16_t count = 0; count < num_name_val_pairs; ++count){
         
         
         // Get the length of the name
-        boost::uint16_t length_name = algorithm::to_uint16(m_uncompressed_ptr);
+        stdx::uint16_t length_name = algorithm::to_uint16(m_uncompressed_ptr);
         std::string name = "";
         
         m_uncompressed_ptr += 2;
         
         {
-            for(boost::uint16_t count = 0; count < length_name; ++count){
+            for(stdx::uint16_t count = 0; count < length_name; ++count){
                 name.push_back(*(m_uncompressed_ptr+count));
             }
             m_uncompressed_ptr += length_name;
         }
         
         // Get the length of the value
-        boost::uint16_t length_value = algorithm::to_uint16(m_uncompressed_ptr);
+        stdx::uint16_t length_value = algorithm::to_uint16(m_uncompressed_ptr);
         std::string value = "";
         
         m_uncompressed_ptr += 2;
         
         {
-            for(boost::uint16_t count = 0; count < length_value; ++count){
+            for(stdx::uint16_t count = 0; count < length_value; ++count){
                 value.push_back(*(m_uncompressed_ptr+count));
             }
             m_uncompressed_ptr += length_value;
@@ -460,7 +460,7 @@ void parser::parse_header_payload(boost::system::error_code &ec,
 
 void parser::parse_spdy_data(boost::system::error_code& /* ec */,
                              const spdy_control_frame_info& frame,
-                             boost::uint32_t /* stream_id */,
+                             stdx::uint32_t /* stream_id */,
                              http_protocol_info& http_info)
 {
     // This marks the finish flag
@@ -472,7 +472,7 @@ void parser::parse_spdy_data(boost::system::error_code& /* ec */,
 void parser::parse_spdy_rst_stream(boost::system::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
-    boost::uint32_t status_code = 0;
+    stdx::uint32_t status_code = 0;
     
     // First complete the check for size and flag
     // The flag for RST frame should be 0, The length should be 8
@@ -504,7 +504,7 @@ void parser::parse_spdy_ping_frame(boost::system::error_code& /* ec */,
         return;
     }
   
-    boost::uint32_t ping_id = 0;
+    stdx::uint32_t ping_id = 0;
     
     // Get the 32 bit ping id
     
@@ -531,7 +531,7 @@ void parser::parse_spdy_goaway_frame(boost::system::error_code &ec,
         return;
     }
     
-    boost::uint32_t status_code = 0;
+    stdx::uint32_t status_code = 0;
     
     // Ignore the 31 bit stream id
     m_read_ptr += 4;

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include <boost/regex.hpp>
 #include <boost/logic/tribool.hpp>
-#include <boost/asio/detail/socket_ops.hpp>
 #include <pion/algorithm.hpp>
 #include <pion/spdy/parser.hpp>
 #include <pion/spdy/decompressor.hpp>

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -54,7 +54,7 @@ parser::parser()
 {}
 
 boost::tribool parser::parse(http_protocol_info& http_info,
-                             boost::system::error_code& ec,
+                             stdx::error_code& ec,
                              const decompressor_ptr& decompressor,
                              const char *packet_ptr,
                              stdx::uint32_t& length_packet,
@@ -138,7 +138,7 @@ stdx::uint32_t parser::get_control_frame_stream_id(const char *ptr)
     return four_bytes & 0x7FFFFFFF;
 }
     
-boost::tribool parser::parse_spdy_frame(boost::system::error_code& ec,
+boost::tribool parser::parse_spdy_frame(stdx::error_code& ec,
                                         const decompressor_ptr& decompressor,
                                         http_protocol_info& http_info,
                                         stdx::uint32_t& length_packet,
@@ -260,7 +260,7 @@ void parser::create_error_category(void)
     m_error_category_ptr = &UNIQUE_ERROR_CATEGORY;
 }
 
-bool parser::populate_frame(boost::system::error_code& ec,
+bool parser::populate_frame(stdx::error_code& ec,
                             spdy_control_frame_info& frame,
                             stdx::uint32_t& length_packet,
                             stdx::uint32_t& stream_id,
@@ -344,7 +344,7 @@ bool parser::populate_frame(boost::system::error_code& ec,
     return true;
 }
 
-void parser::parse_header_payload(boost::system::error_code &ec,
+void parser::parse_header_payload(stdx::error_code &ec,
                                   const decompressor_ptr& decompressor,
                                   const spdy_control_frame_info& frame,
                                   http_protocol_info& http_info,
@@ -457,7 +457,7 @@ void parser::parse_header_payload(boost::system::error_code &ec,
     }
 }
 
-void parser::parse_spdy_data(boost::system::error_code& /* ec */,
+void parser::parse_spdy_data(stdx::error_code& /* ec */,
                              const spdy_control_frame_info& frame,
                              stdx::uint32_t /* stream_id */,
                              http_protocol_info& http_info)
@@ -468,7 +468,7 @@ void parser::parse_spdy_data(boost::system::error_code& /* ec */,
     }
 }
 
-void parser::parse_spdy_rst_stream(boost::system::error_code& /* ec */,
+void parser::parse_spdy_rst_stream(stdx::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
     stdx::uint32_t status_code = 0;
@@ -494,7 +494,7 @@ void parser::parse_spdy_rst_stream(boost::system::error_code& /* ec */,
     }
 }
 
-void parser::parse_spdy_ping_frame(boost::system::error_code& /* ec */,
+void parser::parse_spdy_ping_frame(stdx::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
     // First complete the check for size 
@@ -515,13 +515,13 @@ void parser::parse_spdy_ping_frame(boost::system::error_code& /* ec */,
     PION_LOG_INFO(m_logger, "SPDY " << "Ping ID is : " << ping_id);
 }
 
-void parser::parse_spdy_settings_frame(boost::system::error_code& /* ec */,
+void parser::parse_spdy_settings_frame(stdx::error_code& /* ec */,
                                        const spdy_control_frame_info& /* frame */)
 {
     // Can ignore this frame for our purposes
 }
 
-void parser::parse_spdy_goaway_frame(boost::system::error_code &ec,
+void parser::parse_spdy_goaway_frame(stdx::error_code &ec,
                                      const spdy_control_frame_info& frame)
 {
     // First complete the check for size
@@ -556,7 +556,7 @@ void parser::parse_spdy_goaway_frame(boost::system::error_code &ec,
     
 }
 
-void parser::parse_spdy_window_update_frame(boost::system::error_code& /* ec */,
+void parser::parse_spdy_window_update_frame(stdx::error_code& /* ec */,
                                             const spdy_control_frame_info& /* frame */)
 {
     // TBD : Do we really need this for our purpose

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -7,11 +7,11 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/bind.hpp>
 #include <pion/admin_rights.hpp>
 #include <pion/tcp/server.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/mutex.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -126,7 +126,7 @@ void server::stop(bool wait_until_finished)
         if (! wait_until_finished) {
             // this terminates any other open connections
             std::for_each(m_conn_pool.begin(), m_conn_pool.end(),
-                          boost::bind(&connection::close, _1));
+                          stdx::bind(&connection::close, stdx::placeholders::_1));
         }
     
         // wait for all pending connections to complete
@@ -179,8 +179,8 @@ void server::listen(void)
         // create a new TCP connection object
         tcp::connection_ptr new_connection(connection::create(get_io_service(),
                                                               m_ssl_context, m_ssl_flag,
-                                                              boost::bind(&server::finish_connection,
-                                                                          this, _1)));
+                                                              stdx::bind(&server::finish_connection,
+                                                                         this, stdx::placeholders::_1)));
         
         // prune connections that finished uncleanly
         prune_connections();
@@ -190,7 +190,7 @@ void server::listen(void)
         
         // use the object to accept a new connection
         new_connection->async_accept(m_tcp_acceptor,
-                                     boost::bind(&server::handle_accept,
+                                     stdx::bind(&server::handle_accept,
                                                  this, new_connection,
                                                  stdx::asio::placeholders::error));
     }
@@ -219,7 +219,7 @@ void server::handle_accept(const tcp::connection_ptr& tcp_conn,
         // handle the new connection
 #ifdef PION_HAVE_SSL
         if (tcp_conn->get_ssl_flag()) {
-            tcp_conn->async_handshake_server(boost::bind(&server::handle_ssl_handshake,
+            tcp_conn->async_handshake_server(stdx::bind(&server::handle_ssl_handshake,
                                                          this, tcp_conn,
                                                          stdx::asio::placeholders::error));
         } else

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -7,11 +7,11 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread/mutex.hpp>
 #include <pion/admin_rights.hpp>
 #include <pion/tcp/server.hpp>
+#include <pion/stdx/asio.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -25,19 +25,19 @@ server::server(scheduler& sched, const unsigned int tcp_port)
     m_active_scheduler(sched),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), stdx::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(boost::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
+    m_endpoint(stdx::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
 {}
     
-server::server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
+server::server(scheduler& sched, const stdx::asio::ip::tcp::endpoint& endpoint)
     : m_logger(PION_GET_LOGGER("pion.tcp.server")),
     m_active_scheduler(sched),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), stdx::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
@@ -49,19 +49,19 @@ server::server(const unsigned int tcp_port)
     m_default_scheduler(), m_active_scheduler(m_default_scheduler),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), stdx::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(boost::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
+    m_endpoint(stdx::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
 {}
 
-server::server(const boost::asio::ip::tcp::endpoint& endpoint)
+server::server(const stdx::asio::ip::tcp::endpoint& endpoint)
     : m_logger(PION_GET_LOGGER("pion.tcp.server")),
     m_default_scheduler(), m_active_scheduler(m_default_scheduler),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), stdx::asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
@@ -86,7 +86,7 @@ void server::start(void)
             // allow the acceptor to reuse the address (i.e. SO_REUSEADDR)
             // ...except when running not on Windows - see http://msdn.microsoft.com/en-us/library/ms740621%28VS.85%29.aspx
 #ifndef PION_WIN32
-            m_tcp_acceptor.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+            m_tcp_acceptor.set_option(stdx::asio::ip::tcp::acceptor::reuse_address(true));
 #endif
             m_tcp_acceptor.bind(m_endpoint);
             if (m_endpoint.port() == 0) {
@@ -162,11 +162,11 @@ void server::set_ssl_key_file(const std::string& pem_key_file)
     // configure server for SSL
     set_ssl_flag(true);
 #ifdef PION_HAVE_SSL
-    m_ssl_context.set_options(boost::asio::ssl::context::default_workarounds
-                              | boost::asio::ssl::context::no_sslv2
-                              | boost::asio::ssl::context::single_dh_use);
-    m_ssl_context.use_certificate_file(pem_key_file, boost::asio::ssl::context::pem);
-    m_ssl_context.use_private_key_file(pem_key_file, boost::asio::ssl::context::pem);
+    m_ssl_context.set_options(stdx::asio::ssl::context::default_workarounds
+                              | stdx::asio::ssl::context::no_sslv2
+                              | stdx::asio::ssl::context::single_dh_use);
+    m_ssl_context.use_certificate_file(pem_key_file, stdx::asio::ssl::context::pem);
+    m_ssl_context.use_private_key_file(pem_key_file, stdx::asio::ssl::context::pem);
 #endif
 }
 
@@ -192,7 +192,7 @@ void server::listen(void)
         new_connection->async_accept(m_tcp_acceptor,
                                      boost::bind(&server::handle_accept,
                                                  this, new_connection,
-                                                 boost::asio::placeholders::error));
+                                                 stdx::asio::placeholders::error));
     }
 }
 
@@ -221,7 +221,7 @@ void server::handle_accept(const tcp::connection_ptr& tcp_conn,
         if (tcp_conn->get_ssl_flag()) {
             tcp_conn->async_handshake_server(boost::bind(&server::handle_ssl_handshake,
                                                          this, tcp_conn,
-                                                         boost::asio::placeholders::error));
+                                                         stdx::asio::placeholders::error));
         } else
 #endif
             // not SSL -> call the handler immediately

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -8,10 +8,10 @@
 //
 
 #include <boost/bind.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/admin_rights.hpp>
 #include <pion/tcp/server.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/mutex.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -71,7 +71,7 @@ server::server(const stdx::asio::ip::tcp::endpoint& endpoint)
 void server::start(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    stdx::unique_lock<stdx::mutex> server_lock(m_mutex);
 
     if (! m_is_listening) {
         PION_LOG_INFO(m_logger, "Starting server on port " << get_port());
@@ -113,7 +113,7 @@ void server::start(void)
 void server::stop(bool wait_until_finished)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    stdx::unique_lock<stdx::mutex> server_lock(m_mutex);
 
     if (m_is_listening) {
         PION_LOG_INFO(m_logger, "Shutting down server on port " << get_port());
@@ -150,7 +150,7 @@ void server::stop(bool wait_until_finished)
 
 void server::join(void)
 {
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    stdx::unique_lock<stdx::mutex> server_lock(m_mutex);
     while (m_is_listening) {
         // sleep until server_has_stopped condition is signaled
         m_server_has_stopped.wait(server_lock);
@@ -173,7 +173,7 @@ void server::set_ssl_key_file(const std::string& pem_key_file)
 void server::listen(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    stdx::lock_guard<stdx::mutex> server_lock(m_mutex);
     
     if (m_is_listening) {
         // create a new TCP connection object
@@ -246,7 +246,7 @@ void server::handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
 
 void server::finish_connection(const tcp::connection_ptr& tcp_conn)
 {
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    stdx::lock_guard<stdx::mutex> server_lock(m_mutex);
     if (m_is_listening && tcp_conn->get_keep_alive()) {
         
         // keep the connection alive
@@ -288,7 +288,7 @@ std::size_t server::prune_connections(void)
 
 std::size_t server::get_connections(void) const
 {
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    stdx::lock_guard<stdx::mutex> server_lock(m_mutex);
     return (m_is_listening ? (m_conn_pool.size() - 1) : m_conn_pool.size());
 }
 

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -197,7 +197,7 @@ void server::listen(void)
 }
 
 void server::handle_accept(const tcp::connection_ptr& tcp_conn,
-                             const boost::system::error_code& accept_error)
+                             const stdx::error_code& accept_error)
 {
     if (accept_error) {
         // an error occured while trying to a accept a new connection
@@ -230,7 +230,7 @@ void server::handle_accept(const tcp::connection_ptr& tcp_conn,
 }
 
 void server::handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
-                                   const boost::system::error_code& handshake_error)
+                                   const stdx::error_code& handshake_error)
 {
     if (handshake_error) {
         // an error occured while trying to establish the SSL connection

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -25,7 +25,7 @@ timer::timer(const tcp::connection_ptr& conn_ptr)
 
 void timer::start(const stdx::uint32_t seconds)
 {
-    boost::mutex::scoped_lock timer_lock(m_mutex);
+    stdx::lock_guard<stdx::mutex> timer_lock(m_mutex);
     m_timer_active = true;
     m_timer.expires_from_now(boost::posix_time::seconds(seconds));
     m_timer.async_wait(boost::bind(&timer::timer_callback,
@@ -34,7 +34,7 @@ void timer::start(const stdx::uint32_t seconds)
 
 void timer::cancel(void)
 {
-    boost::mutex::scoped_lock timer_lock(m_mutex);
+    stdx::lock_guard<stdx::mutex> timer_lock(m_mutex);
     m_was_cancelled = true;
     if (m_timer_active)
         m_timer.cancel();
@@ -42,7 +42,7 @@ void timer::cancel(void)
 
 void timer::timer_callback(const boost::system::error_code& /* ec */)
 {
-    boost::mutex::scoped_lock timer_lock(m_mutex);
+    stdx::lock_guard<stdx::mutex> timer_lock(m_mutex);
     m_timer_active = false;
     if (! m_was_cancelled)
         m_conn_ptr->cancel();

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -8,7 +8,7 @@
 //
 
 #include <pion/tcp/timer.hpp>
-#include <boost/bind.hpp>
+#include <pion/stdx/functional.hpp>
 
 
 namespace pion {    // begin namespace pion
@@ -28,8 +28,8 @@ void timer::start(const stdx::uint32_t seconds)
     stdx::lock_guard<stdx::mutex> timer_lock(m_mutex);
     m_timer_active = true;
     m_timer.expires_from_now(boost::posix_time::seconds(seconds));
-    m_timer.async_wait(boost::bind(&timer::timer_callback,
-        shared_from_this(), _1));
+    m_timer.async_wait(stdx::bind(&timer::timer_callback,
+                       shared_from_this(), stdx::placeholders::_1));
 }
 
 void timer::cancel(void)

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -23,7 +23,7 @@ timer::timer(const tcp::connection_ptr& conn_ptr)
 {
 }
 
-void timer::start(const boost::uint32_t seconds)
+void timer::start(const stdx::uint32_t seconds)
 {
     boost::mutex::scoped_lock timer_lock(m_mutex);
     m_timer_active = true;

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -40,7 +40,7 @@ void timer::cancel(void)
         m_timer.cancel();
 }
 
-void timer::timer_callback(const boost::system::error_code& /* ec */)
+void timer::timer_callback(const stdx::error_code& /* ec */)
 {
     stdx::lock_guard<stdx::mutex> timer_lock(m_mutex);
     m_timer_active = false;

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -193,20 +193,20 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     
     algorithm::from_uint8(buf, 129U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x81);
-    BOOST_CHECK_EQUAL(algorithm::to_int8(buf), boost::int8_t(0x81));
+    BOOST_CHECK_EQUAL(algorithm::to_int8(buf), stdx::int8_t(0x81));
     BOOST_CHECK_EQUAL(algorithm::to_uint8(buf), 129U);
 
     algorithm::from_uint16(buf, 32769U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x80);
     BOOST_CHECK_EQUAL(buf[1], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int16(buf), boost::int16_t(0x8001));
+    BOOST_CHECK_EQUAL(algorithm::to_int16(buf), stdx::int16_t(0x8001));
     BOOST_CHECK_EQUAL(algorithm::to_uint16(buf), 32769U);
 
     algorithm::from_uint24(buf, 9642497U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x93);
     BOOST_CHECK_EQUAL(buf[1], (char)0x22);
     BOOST_CHECK_EQUAL(buf[2], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int24(buf), boost::int32_t(0x932201));
+    BOOST_CHECK_EQUAL(algorithm::to_int24(buf), stdx::int32_t(0x932201));
     BOOST_CHECK_EQUAL(algorithm::to_uint24(buf), 9642497U);
 
     algorithm::from_uint32(buf, 2147680769UL);
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[1], (char)0x03);
     BOOST_CHECK_EQUAL(buf[2], (char)0x02);
     BOOST_CHECK_EQUAL(buf[3], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), boost::int32_t(0x80030201));
+    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), stdx::int32_t(0x80030201));
     BOOST_CHECK_EQUAL(algorithm::to_uint32(buf), 2147680769UL);
 
     algorithm::from_uint32(buf, 1427U);
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[1], (char)0x00);
     BOOST_CHECK_EQUAL(buf[2], (char)0x05);
     BOOST_CHECK_EQUAL(buf[3], (char)0x93);
-    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), boost::int32_t(0x00000593));
+    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), stdx::int32_t(0x00000593));
     BOOST_CHECK_EQUAL(algorithm::to_uint32(buf), 1427U);
 
     algorithm::from_uint64(buf, 9223378168241586176ULL);
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[5], (char)0x22);
     BOOST_CHECK_EQUAL(buf[6], (char)0x00);
     BOOST_CHECK_EQUAL(buf[7], (char)0x00);
-    BOOST_CHECK_EQUAL(algorithm::to_int64(buf), boost::int64_t(0x8000059393220000ULL));
+    BOOST_CHECK_EQUAL(algorithm::to_int64(buf), stdx::int64_t(0x8000059393220000ULL));
     BOOST_CHECK_EQUAL(algorithm::to_uint64(buf), 9223378168241586176ULL);
 }
 

--- a/tests/file_service_tests.cpp
+++ b/tests/file_service_tests.cpp
@@ -7,7 +7,6 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/bind.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
@@ -24,6 +23,7 @@
 #include <pion/http/plugin_service.hpp>
 #include <pion/http/plugin_server.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 using namespace pion;
 

--- a/tests/file_service_tests.cpp
+++ b/tests/file_service_tests.cpp
@@ -668,7 +668,7 @@ BOOST_AUTO_TEST_CASE(checkResponseToHTTP_1_1_Request) {
 BOOST_AUTO_TEST_CASE(checkHTTPMessageReceive) {
     // open (another) connection
     pion::tcp::connection tcp_conn(get_io_service());
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 

--- a/tests/file_service_tests.cpp
+++ b/tests/file_service_tests.cpp
@@ -7,7 +7,6 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/lexical_cast.hpp>
@@ -24,6 +23,7 @@
 #include <pion/http/response.hpp>
 #include <pion/http/plugin_service.hpp>
 #include <pion/http/plugin_server.hpp>
+#include <pion/stdx/asio.hpp>
 
 using namespace pion;
 
@@ -109,7 +109,7 @@ public:
         boost::filesystem::remove_all("sandbox");
     }
     
-    inline boost::asio::io_service& get_io_service(void) { return m_scheduler.get_io_service(); }
+    inline stdx::asio::io_service& get_io_service(void) { return m_scheduler.get_io_service(); }
     
     single_service_scheduler	m_scheduler;
 	http::plugin_server			m_server;
@@ -170,7 +170,7 @@ public:
         m_server.start();
 
         // open a connection
-        boost::asio::ip::tcp::endpoint http_endpoint(boost::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
+        stdx::asio::ip::tcp::endpoint http_endpoint(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
         m_http_stream.connect(http_endpoint);
     }
     ~RunningFileService_F() {
@@ -275,7 +275,7 @@ public:
     }
     
     unsigned long m_content_length;
-    boost::asio::ip::tcp::iostream m_http_stream;
+    stdx::asio::ip::tcp::iostream m_http_stream;
     std::map<std::string, std::string> m_response_headers;
 };
 
@@ -669,7 +669,7 @@ BOOST_AUTO_TEST_CASE(checkHTTPMessageReceive) {
     // open (another) connection
     pion::tcp::connection tcp_conn(get_io_service());
     boost::system::error_code error_code;
-    error_code = tcp_conn.connect(boost::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
+    error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
     // send request to the server

--- a/tests/http_message_tests.cpp
+++ b/tests/http_message_tests.cpp
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPRequestNoContent) {
     req.add_header("Test", "Something");
     
     // write to file
-    boost::system::error_code ec;
+    stdx::error_code ec;
     req.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPRequestNoContent) {
     // make sure we're now at EOF
     http::request req3;
     req3.read(m_file, ec);
-    BOOST_CHECK_EQUAL(ec.value(), boost::system::errc::io_error);
+    BOOST_CHECK_EQUAL(ec.value(), stdx::errc::io_error);
     
     // check request read from file
     BOOST_CHECK_EQUAL(req2.get_resource(), "/test.html");
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPResponseNoContent) {
     rsp.add_header("HeaderA", "a value");
     
     // write to file
-    boost::system::error_code ec;
+    stdx::error_code ec;
     rsp.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();
@@ -465,7 +465,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPResponseNoContent) {
     // make sure we're now at EOF
     http::response rsp3;
     rsp3.read(m_file, ec);
-    BOOST_CHECK_EQUAL(ec.value(), boost::system::errc::io_error);
+    BOOST_CHECK_EQUAL(ec.value(), stdx::errc::io_error);
     
     // check response read from file
     BOOST_CHECK_EQUAL(rsp2.get_status_code(), 202U);
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPResponseNoContent) {
 }
 
 BOOST_AUTO_TEST_CASE(checkWriteReadMixedMessages) {
-    boost::system::error_code ec;
+    stdx::error_code ec;
     http::request req;
     http::response rsp;
 
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(checkWriteHTTPRequestWithCookies) {
     req.add_cookie("a", "value");
     
     // write to file
-    boost::system::error_code ec;
+    stdx::error_code ec;
     req.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(checkWriteHTTPResponseWithCookies) {
     rsp.add_cookie("a", "value");
 
     // write to file
-    boost::system::error_code ec;
+    stdx::error_code ec;
     rsp.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleRequest)
     request_parser.set_read_buffer((const char*)request_data_1, sizeof(request_data_1));
 
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
 
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponse)
     response_parser.set_read_buffer((const char*)response_data_1, sizeof(response_data_1));
 
     http::response http_response;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(response_parser.parse(http_response, ec));
     BOOST_CHECK(!ec);
 
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserBadRequest)
     request_parser.set_read_buffer((const char*)request_data_bad, sizeof(request_data_bad));
 
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(!request_parser.parse(http_request, ec));
     BOOST_CHECK_EQUAL(ec.value(), http::parser::ERROR_VERSION_CHAR);
     BOOST_CHECK_EQUAL(ec.message(), "invalid version character");
@@ -505,7 +505,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponseWithSmallerMaxSize)
     response_parser.set_max_content_length(4);
 
     http::response http_response;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(response_parser.parse(http_response, ec));
     BOOST_CHECK(!ec);
 
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponseWithZeroMaxSize)
     response_parser.set_max_content_length(0);
 
     http::response http_response;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(response_parser.parse(http_response, ec));
     BOOST_CHECK(!ec);
 
@@ -547,7 +547,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParser_MultipleResponseFrames)
 
     http::parser response_parser(false);
     http::response http_response;
-    boost::system::error_code ec;
+    stdx::error_code ec;
 
     stdx::uint64_t total_bytes = 0;
     for (int i=0; i <  frame_cnt - 1; i++ ) {
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserWithSemicolons)
                                    sizeof(chunked_request_with_semicolon));
     
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
     
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserWithFooters)
                                    sizeof(chunked_request_with_footers));
     
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
     
@@ -617,7 +617,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserWithErrorInFooters)
                                    sizeof(chunked_request_with_error_in_footers));
     
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     // The HTTP Packet does not contain any footer value associated with the footer key
     // This will lead to any error within the parse_headers() method
@@ -642,7 +642,7 @@ BOOST_AUTO_TEST_CASE(testHTTP_0_9_RequestParser)
     request_parser.set_read_buffer(request_str.c_str(), request_str.length());
     
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
 
     BOOST_CHECK(!ec);
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE(testHTTP_0_9_ResponseParser)
     request_parser.set_read_buffer(request_str.c_str(), request_str.length());
     
     http::request http_request;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
 

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(testParseHttpUri)
     std::string uri("http://127.0.0.1:80/folder/file.ext?q=uery");
     std::string proto;
     std::string host;
-    boost::uint16_t port = 0;
+    stdx::uint16_t port = 0;
     std::string path;
     std::string query;
 
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParser_MultipleResponseFrames)
     http::response http_response;
     boost::system::error_code ec;
 
-    boost::uint64_t total_bytes = 0;
+    stdx::uint64_t total_bytes = 0;
     for (int i=0; i <  frame_cnt - 1; i++ ) {
         response_parser.set_read_buffer((const char*)frames[i], sizes[i]);
         BOOST_CHECK( boost::indeterminate(response_parser.parse(http_response, ec)) );

--- a/tests/http_plugin_server_tests.cpp
+++ b/tests/http_plugin_server_tests.cpp
@@ -9,7 +9,6 @@
 
 
 #include <pion/config.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
@@ -29,6 +28,7 @@
 #include <pion/stdx/mutex.hpp>
 #include <pion/stdx/condition_variable.hpp>
 #include <pion/stdx/functional.hpp>
+#include <pion/stdx/memory.hpp>
 
 
 using namespace std;
@@ -56,7 +56,7 @@ PION_DECLARE_PLUGIN(CookieService)
 
 /// generates chunked POST requests for testing purposes
 class ChunkedPostRequestSender : 
-    public boost::enable_shared_from_this<ChunkedPostRequestSender>,
+    public stdx::enable_shared_from_this<ChunkedPostRequestSender>,
     private boost::noncopyable
 {
 public:
@@ -66,10 +66,10 @@ public:
      * @param tcp_conn TCP connection used to send the file
      * @param resource
      */
-    static inline boost::shared_ptr<ChunkedPostRequestSender>
+    static inline stdx::shared_ptr<ChunkedPostRequestSender>
         create(const pion::tcp::connection_ptr& tcp_conn, const std::string& resource)
     {
-        return boost::shared_ptr<ChunkedPostRequestSender>(new ChunkedPostRequestSender(tcp_conn, resource));
+        return stdx::shared_ptr<ChunkedPostRequestSender>(new ChunkedPostRequestSender(tcp_conn, resource));
     }
     
     ~ChunkedPostRequestSender() {
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE(checkSendChunkedRequestAndReceiveResponse) {
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
-    boost::shared_ptr<ChunkedPostRequestSender> sender = ChunkedPostRequestSender::create(tcp_conn, "/echo");
+    stdx::shared_ptr<ChunkedPostRequestSender> sender = ChunkedPostRequestSender::create(tcp_conn, "/echo");
     sender->addChunk(5, "klmno");
     sender->addChunk(4, "1234");
     sender->addChunk(10, "abcdefghij");
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(checkSendChunkedRequestWithOneChunkAndReceiveResponse) {
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
-    boost::shared_ptr<ChunkedPostRequestSender> sender = ChunkedPostRequestSender::create(tcp_conn, "/echo");
+    stdx::shared_ptr<ChunkedPostRequestSender> sender = ChunkedPostRequestSender::create(tcp_conn, "/echo");
     sender->addChunk(10, "abcdefghij");
     sender->send();
 
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(checkSendChunkedRequestWithNoChunksAndReceiveResponse) {
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
-    boost::shared_ptr<ChunkedPostRequestSender> sender = ChunkedPostRequestSender::create(tcp_conn, "/echo");
+    stdx::shared_ptr<ChunkedPostRequestSender> sender = ChunkedPostRequestSender::create(tcp_conn, "/echo");
     sender->send();
 
     // receive the response from the server

--- a/tests/http_plugin_server_tests.cpp
+++ b/tests/http_plugin_server_tests.cpp
@@ -98,7 +98,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    void handle_write(const boost::system::error_code& write_error,
+    void handle_write(const stdx::error_code& write_error,
                      std::size_t bytes_written);
 
 private:
@@ -154,7 +154,7 @@ void ChunkedPostRequestSender::send(void)
     }
 }
 
-void ChunkedPostRequestSender::handle_write(const boost::system::error_code& write_error,
+void ChunkedPostRequestSender::handle_write(const stdx::error_code& write_error,
                                            std::size_t bytes_written)
 {
     (void)bytes_written;
@@ -342,7 +342,7 @@ public:
     inline void checkSendAndReceiveMessages(pion::tcp::connection& tcp_conn) {
         // send valid request to the server
         http::request http_request("/hello");
-        boost::system::error_code error_code;
+        stdx::error_code error_code;
         http_request.send(tcp_conn, error_code);
         BOOST_REQUIRE(! error_code);
 
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(checkSendRequestsAndReceiveResponses) {
     // open a connection
     pion::tcp::connection tcp_conn(get_io_service());
     tcp_conn.set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(! error_code);
     
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(checkSendRequestsAndReceiveResponseLeftoverConnection) {
     // open a connection
     pion::tcp::connection tcp_conn(get_io_service());
     tcp_conn.set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(! error_code);
     
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(checkSendRequestAndReceiveResponseFromEchoService) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(checkSendChunkedRequestAndReceiveResponse) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(checkSendChunkedRequestWithOneChunkAndReceiveResponse) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -612,7 +612,7 @@ BOOST_AUTO_TEST_CASE(checkSendChunkedRequestWithNoChunksAndReceiveResponse) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(checkSendRequestsAndReceiveResponsesUsingSSL) {
     // open a connection
     pion::tcp::connection tcp_conn(get_io_service(), true);
     tcp_conn.set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(! error_code);
     error_code = tcp_conn.handshake_client();
@@ -661,7 +661,7 @@ BOOST_AUTO_TEST_CASE(checkSendRequestsAndReceiveResponseLeftoverConnectionUsingS
     // open a connection
     pion::tcp::connection tcp_conn(get_io_service(), true);
     tcp_conn.set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(! error_code);
     error_code = tcp_conn.handshake_client();
@@ -885,7 +885,7 @@ BOOST_AUTO_TEST_CASE(checkBasicAuthServiceFailure) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
     
@@ -922,7 +922,7 @@ BOOST_AUTO_TEST_CASE(checkBasicAuthServiceLogin) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
     
@@ -961,7 +961,7 @@ BOOST_AUTO_TEST_CASE(checkCookieAuthServiceFailure) {
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -998,7 +998,7 @@ BOOST_AUTO_TEST_CASE(checkCookieAuthServiceLogin) {
     // open a login connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
     tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_KEEPALIVE);
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -1088,7 +1088,7 @@ public:
         http_response.set_do_not_send_content_length();
         
         // send the response headers
-        boost::system::error_code error_code;
+        stdx::error_code error_code;
         http_response.send(*tcp_conn, error_code);
         BOOST_REQUIRE(! error_code);
         
@@ -1121,7 +1121,7 @@ public:
     
     /// checks the validity of the HTTP response
     void checkResponse(http::response_ptr& http_response_ptr,
-        tcp::connection_ptr& /* conn_ptr */, const boost::system::error_code& /* ec */)
+        tcp::connection_ptr& /* conn_ptr */, const stdx::error_code& /* ec */)
     {
         checkResponse(*http_response_ptr);
         stdx::lock_guard<stdx::mutex> async_lock(m_mutex);
@@ -1151,7 +1151,7 @@ BOOST_AUTO_TEST_CASE(checkSendContentWithoutLengthAndReceiveSyncResponse) {
     
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
@@ -1177,7 +1177,7 @@ BOOST_AUTO_TEST_CASE(checkSendContentWithoutLengthAndReceiveAsyncResponse) {
     
     // open a connection
     tcp::connection_ptr tcp_conn(new pion::tcp::connection(get_io_service()));
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn->connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
     

--- a/tests/spdy_parser_tests.cpp
+++ b/tests/spdy_parser_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_SUITE(parser_S, parser_F)
 BOOST_AUTO_TEST_CASE(test_is_spdy_frame_methods)
 {
     // Try with a invalid SPDY frame
-    boost::uint16_t sample_frame = 0xFF;
+    stdx::uint16_t sample_frame = 0xFF;
     boost::system::error_code ec;
     
     BOOST_CHECK_EQUAL(parser::get_spdy_frame_type((const char *)&(sample_frame)), spdy_invalid_frame);
@@ -95,10 +95,10 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_reply_frame)
     http_protocol_info http_info;
     
     // The length is known for this packet
-    boost::uint32_t length_packet = 1460;
+    stdx::uint32_t length_packet = 1460;
     
     spdy_control_frame_info frame;
-    boost::uint32_t                stream_id = 0;
+    stdx::uint32_t                stream_id = 0;
     
     this->set_read_ptr((const char*)spdy_syn_reply_frame);
     
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_rst_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    stdx::uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_goaway_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    stdx::uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_frames)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    stdx::uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_ping_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    stdx::uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_stream_frame)
     http_protocol_info http_info;
     
     // The length is known for this packet
-    boost::uint32_t length_packet = 294;
+    stdx::uint32_t length_packet = 294;
     
     spdy_control_frame_info frame;
-    boost::uint32_t                stream_id = 0;
+    stdx::uint32_t                stream_id = 0;
     
     this->set_read_ptr((const char*)spdy_syn_stream_frame);
     
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_interleaved_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 1460;
+    stdx::uint32_t length_packet = 1460;
     
     boost::tribool result = false;
     
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_header)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 1460;
+    stdx::uint32_t length_packet = 1460;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_syn_stream_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 294;
+    stdx::uint32_t length_packet = 294;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_datastream_frame)
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
 
     http_protocol_info   http_info;
-    boost::uint32_t length_packet = 1460;
+    stdx::uint32_t length_packet = 1460;
 
     boost::tribool result = false;
     

--- a/tests/spdy_parser_tests.cpp
+++ b/tests/spdy_parser_tests.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(test_is_spdy_frame_methods)
 {
     // Try with a invalid SPDY frame
     stdx::uint16_t sample_frame = 0xFF;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     BOOST_CHECK_EQUAL(parser::get_spdy_frame_type((const char *)&(sample_frame)), spdy_invalid_frame);
     BOOST_CHECK_EQUAL(parser::is_spdy_control_frame((const char *)&(sample_frame)), false);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_reply_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    stdx::error_code ec;
     http_protocol_info http_info;
     
     // The length is known for this packet
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_rst_frame)
     // Parse a spdy rst frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_goaway_frame)
     // Parse a spdy go away frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_frames)
     // any unwanted conditions like seg faults etx
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_ping_frame)
     // Parse a spdy ping frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_stream_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    stdx::error_code ec;
     http_protocol_info http_info;
     
     // The length is known for this packet
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_interleaved_frame)
     // Parse a spdy response frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_header)
     // Parse a spdy response frame
     
     http_protocol_info          http_info;
-    boost::system::error_code   ec;
+    stdx::error_code   ec;
     
     // Check for interleaved spdy frames
     // The length is known for this packet
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_syn_stream_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     // Check for interleaved spdy frames
     // The length is known for this packet
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_datastream_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    stdx::error_code ec;
     
     // Check for interleaved spdy frames
     // The length is known for this packet

--- a/tests/tcp_server_tests.cpp
+++ b/tests/tcp_server_tests.cpp
@@ -10,13 +10,12 @@
 #include <pion/config.hpp>
 #include <pion/scheduler.hpp>
 #include <pion/tcp/server.hpp>
-#include <boost/bind.hpp>
-#include <boost/function/function1.hpp>
 #include <boost/test/unit_test.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/response.hpp>
 #include <pion/stdx/asio.hpp>
 #include <pion/stdx/thread.hpp>
+#include <pion/stdx/functional.hpp>
 
 using namespace std;
 using namespace pion;
@@ -47,7 +46,7 @@ public:
         static const std::string HELLO_MESSAGE("Hello there!\n");
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE);  // make sure it will get closed
         tcp_conn->async_write(stdx::asio::buffer(HELLO_MESSAGE),
-                              boost::bind(&HelloServer::handle_write, this, tcp_conn,
+                              stdx::bind(&HelloServer::handle_write, this, tcp_conn,
                                           stdx::asio::placeholders::error));
     }
 
@@ -66,7 +65,7 @@ private:
         if (write_error) {
             tcp_conn->finish();
         } else {
-            tcp_conn->async_read_some(boost::bind(&HelloServer::handleRead, this, tcp_conn,
+            tcp_conn->async_read_some(stdx::bind(&HelloServer::handleRead, this, tcp_conn,
                                                   stdx::asio::placeholders::error,
                                                   stdx::asio::placeholders::bytes_transferred));
         }
@@ -90,7 +89,7 @@ private:
             throw int(1);
         } else {
             tcp_conn->async_write(stdx::asio::buffer(GOODBYE_MESSAGE),
-                                  boost::bind(&pion::tcp::connection::finish, tcp_conn));
+                                  stdx::bind(&pion::tcp::connection::finish, tcp_conn));
         }
     }
 };
@@ -280,7 +279,7 @@ public:
 
     void setExpectations(const std::map<std::string, std::string>& expectedHeaders, 
                          const std::string& expectedContent,
-                         boost::function1<bool, http::request&> additional_request_test = NULL)
+                         stdx::function<bool(http::request&)> additional_request_test = NULL)
     {
         m_expectedHeaders = expectedHeaders;
         m_expectedContent = expectedContent;
@@ -290,7 +289,7 @@ public:
 private:
     std::map<std::string, std::string> m_expectedHeaders;
     std::string m_expectedContent;
-    boost::function1<bool, http::request&> m_additional_request_test;
+    stdx::function<bool(http::request&)> m_additional_request_test;
 };
 
 

--- a/tests/tcp_server_tests.cpp
+++ b/tests/tcp_server_tests.cpp
@@ -306,12 +306,12 @@ public:
     ~MockSyncServerTests_F() {
         m_sync_server_ptr->stop();
     }
-    inline boost::shared_ptr<MockSyncServer>& getServerPtr(void) { return m_sync_server_ptr; }
+    inline stdx::shared_ptr<MockSyncServer>& getServerPtr(void) { return m_sync_server_ptr; }
     inline stdx::asio::io_service& get_io_service(void) { return m_scheduler.get_io_service(); }
 
 private:
     single_service_scheduler          m_scheduler;
-    boost::shared_ptr<MockSyncServer>   m_sync_server_ptr;
+    stdx::shared_ptr<MockSyncServer>   m_sync_server_ptr;
 };
 
 

--- a/tests/tcp_server_tests.cpp
+++ b/tests/tcp_server_tests.cpp
@@ -60,7 +60,7 @@ private:
      * @param write_error message that explains what went wrong (if anything)
      */
     void handle_write(const pion::tcp::connection_ptr& tcp_conn,
-                     const boost::system::error_code& write_error)
+                     const stdx::error_code& write_error)
     {
         if (write_error) {
             tcp_conn->finish();
@@ -79,7 +79,7 @@ private:
      * @param bytes_read number of bytes read from the client
      */
     void handleRead(const pion::tcp::connection_ptr& tcp_conn,
-                    const boost::system::error_code& read_error,
+                    const stdx::error_code& read_error,
                     std::size_t bytes_read)
     {
         static const std::string GOODBYE_MESSAGE("Goodbye!\n");
@@ -254,7 +254,7 @@ public:
      */
     virtual void handle_connection(const pion::tcp::connection_ptr& tcp_conn) {
         // wait until an HTTP request is received or an error occurs
-        boost::system::error_code error_code;
+        stdx::error_code error_code;
         http::request http_request;
         http_request.receive(*tcp_conn, error_code);
         BOOST_REQUIRE(!error_code);
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(checkReceivedRequestUsingExtraWhiteSpaceAroundChunkSizes) {
 BOOST_AUTO_TEST_CASE(checkReceivedRequestUsingRequestObject) {
     // open a connection
     pion::tcp::connection tcp_conn(get_io_service());
-    boost::system::error_code error_code;
+    stdx::error_code error_code;
     error_code = tcp_conn.connect(stdx::asio::ip::address::from_string("127.0.0.1"), getServerPtr()->get_port());
     BOOST_REQUIRE(!error_code);
 

--- a/tests/tcp_server_tests.cpp
+++ b/tests/tcp_server_tests.cpp
@@ -12,11 +12,11 @@
 #include <pion/tcp/server.hpp>
 #include <boost/bind.hpp>
 #include <boost/function/function1.hpp>
-#include <boost/thread/thread.hpp>
 #include <boost/test/unit_test.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/response.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/thread.hpp>
 
 using namespace std;
 using namespace pion;

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -56,7 +56,7 @@ public:
         // notify test thread that we are ready to accept a connection
         {
             // wait for test thread to be waiting on the signal
-            boost::unique_lock<boost::mutex> accept_lock(m_accept_mutex);
+            stdx::unique_lock<stdx::mutex> accept_lock(m_accept_mutex);
             // trigger signal to wake test thread
             m_port = tcp_acceptor.local_endpoint().port();
             m_accept_ready.notify_one();
@@ -85,10 +85,10 @@ public:
     single_service_scheduler      m_scheduler;
 
     /// used to notify test thread when acceptConnection() is ready
-    boost::condition                m_accept_ready;
+    stdx::condition_variable                m_accept_ready;
     
     /// used to sync test thread with acceptConnection()
-    boost::mutex                    m_accept_mutex;
+    stdx::mutex                    m_accept_mutex;
 };
 
 
@@ -97,11 +97,11 @@ public:
 BOOST_FIXTURE_TEST_SUITE(tcp_stream_tests_S, tcp_stream_tests_F)
 
 BOOST_AUTO_TEST_CASE(checkTCPConnectToAnotherStream) {
-    boost::unique_lock<boost::mutex> accept_lock(m_accept_mutex);
+    stdx::unique_lock<stdx::mutex> accept_lock(m_accept_mutex);
 
     // schedule another thread to listen for a TCP connection
     connection_handler conn_handler(boost::bind(&tcp_stream_tests_F::sendHello, _1));
-    boost::thread listener_thread(boost::bind(&tcp_stream_tests_F::acceptConnection,
+    stdx::thread listener_thread(boost::bind(&tcp_stream_tests_F::acceptConnection,
                                               this, conn_handler) );
     m_scheduler.add_active_user();
     m_accept_ready.wait(accept_lock);
@@ -156,11 +156,11 @@ public:
 BOOST_FIXTURE_TEST_SUITE(tcp_stream_buffer_tests_S, tcp_stream_buffer_tests_F)
 
 BOOST_AUTO_TEST_CASE(checkSendAndReceiveBiggerThanBuffers) {
-    boost::unique_lock<boost::mutex> accept_lock(m_accept_mutex);
+    stdx::unique_lock<stdx::mutex> accept_lock(m_accept_mutex);
 
     // schedule another thread to listen for a TCP connection
     connection_handler conn_handler(boost::bind(&tcp_stream_buffer_tests_F::sendBigBuffer, this, _1));
-    boost::thread listener_thread(boost::bind(&tcp_stream_buffer_tests_F::acceptConnection,
+    stdx::thread listener_thread(boost::bind(&tcp_stream_buffer_tests_F::acceptConnection,
                                               this, conn_handler) );
     m_scheduler.add_active_user();
     m_accept_ready.wait(accept_lock);

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -7,16 +7,15 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/bind.hpp>
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/thread.hpp>
 #pragma GCC diagnostic warning "-Wunused-parameter"
-#include <boost/function.hpp>
 #include <boost/test/unit_test.hpp>
 #include <pion/config.hpp>
 #include <pion/scheduler.hpp>
 #include <pion/tcp/stream.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 using namespace std;
 using namespace pion;
@@ -29,7 +28,7 @@ class tcp_stream_tests_F {
 public:
     
     /// data type for a function that handles tcp::stream connections
-    typedef boost::function1<void,tcp::stream&>   connection_handler;
+    typedef stdx::function<void(tcp::stream&)>   connection_handler;
     
     
     // default constructor and destructor
@@ -100,8 +99,8 @@ BOOST_AUTO_TEST_CASE(checkTCPConnectToAnotherStream) {
     stdx::unique_lock<stdx::mutex> accept_lock(m_accept_mutex);
 
     // schedule another thread to listen for a TCP connection
-    connection_handler conn_handler(boost::bind(&tcp_stream_tests_F::sendHello, _1));
-    stdx::thread listener_thread(boost::bind(&tcp_stream_tests_F::acceptConnection,
+    connection_handler conn_handler(stdx::bind(&tcp_stream_tests_F::sendHello, stdx::placeholders::_1));
+    stdx::thread listener_thread(stdx::bind(&tcp_stream_tests_F::acceptConnection,
                                               this, conn_handler) );
     m_scheduler.add_active_user();
     m_accept_ready.wait(accept_lock);
@@ -159,8 +158,8 @@ BOOST_AUTO_TEST_CASE(checkSendAndReceiveBiggerThanBuffers) {
     stdx::unique_lock<stdx::mutex> accept_lock(m_accept_mutex);
 
     // schedule another thread to listen for a TCP connection
-    connection_handler conn_handler(boost::bind(&tcp_stream_buffer_tests_F::sendBigBuffer, this, _1));
-    stdx::thread listener_thread(boost::bind(&tcp_stream_buffer_tests_F::acceptConnection,
+    connection_handler conn_handler(stdx::bind(&tcp_stream_buffer_tests_F::sendBigBuffer, this, stdx::placeholders::_1));
+    stdx::thread listener_thread(stdx::bind(&tcp_stream_buffer_tests_F::acceptConnection,
                                               this, conn_handler) );
     m_scheduler.add_active_user();
     m_accept_ready.wait(accept_lock);

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -63,7 +63,7 @@ public:
 
         // schedule another thread to listen for a TCP connection
         tcp::stream listener_stream(m_scheduler.get_io_service());
-        boost::system::error_code ec = listener_stream.accept(tcp_acceptor);
+        stdx::error_code ec = listener_stream.accept(tcp_acceptor);
         tcp_acceptor.close();
         BOOST_REQUIRE(! ec);
         
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(checkTCPConnectToAnotherStream) {
 
     // connect to the listener
     tcp::stream client_str(m_scheduler.get_io_service());
-    boost::system::error_code ec;
+    stdx::error_code ec;
     ec = client_str.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_port);
     BOOST_REQUIRE(! ec);
     
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(checkSendAndReceiveBiggerThanBuffers) {
 
     // connect to the listener
     tcp::stream client_str(m_scheduler.get_io_service());
-    boost::system::error_code ec;
+    stdx::error_code ec;
     ec = client_str.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_port);
     BOOST_REQUIRE(! ec);
     

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -7,7 +7,6 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/thread.hpp>
@@ -17,6 +16,7 @@
 #include <pion/config.hpp>
 #include <pion/scheduler.hpp>
 #include <pion/tcp/stream.hpp>
+#include <pion/stdx/asio.hpp>
 
 using namespace std;
 using namespace pion;
@@ -44,12 +44,12 @@ public:
      */
     void acceptConnection(connection_handler conn_handler) {
         // configure the acceptor service
-        boost::asio::ip::tcp::acceptor   tcp_acceptor(m_scheduler.get_io_service());
-        boost::asio::ip::tcp::endpoint   tcp_endpoint(boost::asio::ip::tcp::v4(), 0);
+        stdx::asio::ip::tcp::acceptor   tcp_acceptor(m_scheduler.get_io_service());
+        stdx::asio::ip::tcp::endpoint   tcp_endpoint(stdx::asio::ip::tcp::v4(), 0);
         tcp_acceptor.open(tcp_endpoint.protocol());
 
         // allow the acceptor to reuse the address (i.e. SO_REUSEADDR)
-        tcp_acceptor.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+        tcp_acceptor.set_option(stdx::asio::ip::tcp::acceptor::reuse_address(true));
         tcp_acceptor.bind(tcp_endpoint);
         tcp_acceptor.listen();
 
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(checkTCPConnectToAnotherStream) {
     // connect to the listener
     tcp::stream client_str(m_scheduler.get_io_service());
     boost::system::error_code ec;
-    ec = client_str.connect(boost::asio::ip::address::from_string("127.0.0.1"), m_port);
+    ec = client_str.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_port);
     BOOST_REQUIRE(! ec);
     
     // get the hello message
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(checkSendAndReceiveBiggerThanBuffers) {
     // connect to the listener
     tcp::stream client_str(m_scheduler.get_io_service());
     boost::system::error_code ec;
-    ec = client_str.connect(boost::asio::ip::address::from_string("127.0.0.1"), m_port);
+    ec = client_str.connect(stdx::asio::ip::address::from_string("127.0.0.1"), m_port);
     BOOST_REQUIRE(! ec);
     
     // read the big buffer contents

--- a/utils/helloserver.cpp
+++ b/utils/helloserver.cpp
@@ -8,11 +8,11 @@
 //
 
 #include <iostream>
-#include <boost/bind.hpp>
 #include <pion/error.hpp>
 #include <pion/process.hpp>
 #include <pion/tcp/server.hpp>
 #include <pion/stdx/asio.hpp>
+#include <pion/stdx/functional.hpp>
 
 using namespace std;
 using namespace pion;
@@ -28,7 +28,7 @@ public:
         static const std::string HELLO_MESSAGE("Hello there!\x0D\x0A");
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE); // make sure it will get closed
         tcp_conn->async_write(stdx::asio::buffer(HELLO_MESSAGE),
-                              boost::bind(&pion::tcp::connection::finish, tcp_conn));
+                              stdx::bind(&pion::tcp::connection::finish, tcp_conn));
     }
 };
 

--- a/utils/helloserver.cpp
+++ b/utils/helloserver.cpp
@@ -8,11 +8,11 @@
 //
 
 #include <iostream>
-#include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <pion/error.hpp>
 #include <pion/process.hpp>
 #include <pion/tcp/server.hpp>
+#include <pion/stdx/asio.hpp>
 
 using namespace std;
 using namespace pion;
@@ -27,7 +27,7 @@ public:
     {
         static const std::string HELLO_MESSAGE("Hello there!\x0D\x0A");
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE); // make sure it will get closed
-        tcp_conn->async_write(boost::asio::buffer(HELLO_MESSAGE),
+        tcp_conn->async_write(stdx::asio::buffer(HELLO_MESSAGE),
                               boost::bind(&pion::tcp::connection::finish, tcp_conn));
     }
 };

--- a/utils/piond.cpp
+++ b/utils/piond.cpp
@@ -9,11 +9,11 @@
 
 #include <vector>
 #include <iostream>
-#include <boost/asio.hpp>
 #include <pion/error.hpp>
 #include <pion/plugin.hpp>
 #include <pion/process.hpp>
 #include <pion/http/plugin_server.hpp>
+#include <pion/stdx/asio.hpp>
 
 // these are used only when linking to static web service libraries
 // #ifdef PION_STATIC_LINKING
@@ -46,7 +46,7 @@ int main (int argc, char *argv[])
     ServiceOptionsType service_options;
     
     // parse command line: determine port number, RESOURCE and WEBSERVICE
-    boost::asio::ip::tcp::endpoint cfg_endpoint(boost::asio::ip::tcp::v4(), DEFAULT_PORT);
+    stdx::asio::ip::tcp::endpoint cfg_endpoint(stdx::asio::ip::tcp::v4(), DEFAULT_PORT);
     std::string service_config_file;
     std::string resource_name;
     std::string service_name;
@@ -63,7 +63,7 @@ int main (int argc, char *argv[])
                 if (cfg_endpoint.port() == 0) cfg_endpoint.port(DEFAULT_PORT);
             } else if (argv[argnum][1] == 'i' && argv[argnum][2] == '\0' && argnum+1 < argc) {
                 // set ip address
-                cfg_endpoint.address(boost::asio::ip::address::from_string(argv[++argnum]));
+                cfg_endpoint.address(stdx::asio::ip::address::from_string(argv[++argnum]));
             } else if (argv[argnum][1] == 'c' && argv[argnum][2] == '\0' && argnum+1 < argc) {
                 service_config_file = argv[++argnum];
             } else if (argv[argnum][1] == 'd' && argv[argnum][2] == '\0' && argnum+1 < argc) {


### PR DESCRIPTION
The standalone ASIO doesn't use the boost types, it uses the C++11 standard ones. This PR is a PoC of a mechanism to let PION either use the C++11 types and the standalone ASIO, or use boost for both ASIO and C++11-esque things.

It isn't 100% complete, as there are few more things that could be shimmed (regex, random), and a few things that would still need some thought (scoped_array and shared_array), since they don't have 1:1 analogues. I've also not even tried to run any tests - just getting it to build (also I coudn't figure out how to run the tests from a CMake build).

For the most part, the code changes are mechanically changing boost:: -> stdx:: and updating the headers. There are a few places where I had to make some smaller spot changes, but they are rare.

Please note that I tried to sign the CLA in case there is actual interest in merging this, but I was unable to do so per https://github.com/splunk/pion/issues/101

Note that the technique used here is modeled heavily on the one used in MongoDB as it transitioned from C++03 to C++11:

https://github.com/mongodb/mongo/tree/master/src/mongo/stdx

Thanks,
Andrew
