### PR TITLE
C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ message(">>> EXECUTABLE_OUTPUT_PATH = ${EXECUTABLE_OUTPUT_PATH}")
 # general
 option(BUILD_SHARED_LIBS "Build Pion as shared library" ON)
 option(BUILD_SPDY "Enable SPDY" OFF)
-option(BUILD_UT "Enable Unit test" OFF)
+option(BUILD_UT "Enable Unit test" ON)
 
 # utils
 option(BUILD_PIOND "Enable piond" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,11 +78,11 @@ include_directories(${PROJECT_WIDE_INCLUDE})
 find_package(Threads REQUIRED)
 
 # TODO: need to handle this with option
-set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_MULTITHREADED OFF)
 #set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 
-find_package(Boost COMPONENTS thread system filesystem regex unit_test_framework REQUIRED)
+find_package(Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
 if (Boost_FOUND)
     # disable autolinking feature
     add_definitions(-DBOOST_ALL_NO_LIB)

--- a/build/pion-boost.inc
+++ b/build/pion-boost.inc
@@ -72,22 +72,22 @@ AC_SUBST(BOOST_SYSTEM_LIB)
 
 
 # Check for Boost Thread library
-BOOST_TRY_LIB=thread
-BOOST_TRY_LINK="boost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}"
-LIBS_SAVED="$LIBS"
-LIBS="$LIBS_SAVED -l${BOOST_TRY_LINK} ${BOOST_SYSTEM_LIB} ${BOOST_DATE_TIME_LIB}"
-AC_MSG_CHECKING([for boost::${BOOST_TRY_LIB} library])
-AC_TRY_LINK([#include <boost/thread/thread.hpp>
-	#include <boost/thread/condition.hpp>],
-	[ boost::thread current_thread; return 0; ],
-	[ AC_MSG_RESULT(ok)
-	  BOOST_THREAD_LIB="-l${BOOST_TRY_LINK}"
-	],
-	[ AC_MSG_RESULT(not found)
-	  AC_MSG_ERROR(Unable to link with the boost::${BOOST_TRY_LIB} library)
-	])
-LIBS="$LIBS_SAVED"
-AC_SUBST(BOOST_THREAD_LIB)
+#BOOST_TRY_LIB=thread
+#BOOST_TRY_LINK="boost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}"
+#LIBS_SAVED="$LIBS"
+#LIBS="$LIBS_SAVED -l${BOOST_TRY_LINK} ${BOOST_SYSTEM_LIB} ${BOOST_DATE_TIME_LIB}"
+#AC_MSG_CHECKING([for boost::${BOOST_TRY_LIB} library])
+#AC_TRY_LINK([#include <boost/thread/thread.hpp>
+#	#include <boost/thread/condition.hpp>],
+#	[ boost::thread current_thread; return 0; ],
+#	[ AC_MSG_RESULT(ok)
+#	  BOOST_THREAD_LIB="-l${BOOST_TRY_LINK}"
+#	],
+#	[ AC_MSG_RESULT(not found)
+#	  AC_MSG_ERROR(Unable to link with the boost::${BOOST_TRY_LIB} library)
+#	])
+#LIBS="$LIBS_SAVED"
+#AC_SUBST(BOOST_THREAD_LIB)
 
 
 # Check for Boost Filesystem library
@@ -109,21 +109,21 @@ AC_SUBST(BOOST_FILESYSTEM_LIB)
 
 
 # Check for Boost Regex library
-BOOST_TRY_LIB=regex
-BOOST_TRY_LINK="boost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}"
-LIBS_SAVED="$LIBS"
-LIBS="$LIBS_SAVED -l${BOOST_TRY_LINK}"
-AC_MSG_CHECKING([for boost::${BOOST_TRY_LIB} library])
-AC_TRY_LINK([#include <boost/regex.hpp>],
-	[ boost::regex exp(".*"); return 0; ],
-	[ AC_MSG_RESULT(ok)
-	  BOOST_REGEX_LIB="-l${BOOST_TRY_LINK}"
-	],
-	[ AC_MSG_RESULT(not found)
-	  AC_MSG_ERROR(Unable to link with the boost::${BOOST_TRY_LIB} library)
-	])
-LIBS="$LIBS_SAVED"
-AC_SUBST(BOOST_REGEX_LIB)
+#BOOST_TRY_LIB=regex
+#BOOST_TRY_LINK="boost_${BOOST_TRY_LIB}${BOOST_LIB_EXTENSION}"
+#LIBS_SAVED="$LIBS"
+#LIBS="$LIBS_SAVED -l${BOOST_TRY_LINK}"
+#AC_MSG_CHECKING([for boost::${BOOST_TRY_LIB} library])
+#AC_TRY_LINK([#include <boost/regex.hpp>],
+#	[ std::regex exp(".*"); return 0; ],
+#	[ AC_MSG_RESULT(ok)
+#	  BOOST_REGEX_LIB="-l${BOOST_TRY_LINK}"
+#	],
+#	[ AC_MSG_RESULT(not found)
+#	  AC_MSG_ERROR(Unable to link with the boost::${BOOST_TRY_LIB} library)
+#	])
+#LIBS="$LIBS_SAVED"
+#AC_SUBST(BOOST_REGEX_LIB)
 
 
 # Check for Boost Unit Test Framework

--- a/build/pion-boost.inc
+++ b/build/pion-boost.inc
@@ -60,7 +60,7 @@ LIBS_SAVED="$LIBS"
 LIBS="$LIBS_SAVED -l${BOOST_TRY_LINK}"
 AC_MSG_CHECKING([for boost::${BOOST_TRY_LIB} library])
 AC_TRY_LINK([#include <boost/system/error_code.hpp>],
-	[ boost::system::error_code error_code; std::string message(error_code.message()); return 0; ],
+	[ asio::error_code error_code; std::string message(error_code.message()); return 0; ],
 	[ AC_MSG_RESULT(ok)
 	  BOOST_SYSTEM_LIB="-l${BOOST_TRY_LINK}"
 	],

--- a/include/pion/admin_rights.hpp
+++ b/include/pion/admin_rights.hpp
@@ -12,8 +12,7 @@
 
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
-#include <boost/cstdint.hpp>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 
 namespace pion {    // begin namespace pion
@@ -60,19 +59,19 @@ private:
 
 
     /// adminisitrator or root user identifier
-    static const boost::int16_t         ADMIN_USER_ID;
+    static const int16_t         ADMIN_USER_ID;
 
     /// mutex used to prevent multiple threads from corrupting user id
-    static boost::mutex                 m_mutex;
+    static std::mutex                 m_mutex;
 
     /// primary logging interface used by this class        
     logger                              m_logger;
 
     /// lock used to prevent multiple threads from corrupting user id
-    boost::unique_lock<boost::mutex>    m_lock;
+    std::unique_lock<std::mutex>    m_lock;
 
     /// saved user identifier before upgrading to administrator
-    boost::int16_t                      m_user_id;
+    int16_t                      m_user_id;
 
     /// true if the class currently holds administrative rights
     bool                                m_has_rights;

--- a/include/pion/admin_rights.hpp
+++ b/include/pion/admin_rights.hpp
@@ -53,31 +53,31 @@ private:
      * @param name descriptive name to lookup (user or group name, may be id)
      * @param file system credentials file to look within
      *
-     * @return int32_t identifier found, or -1 if none found
+     * @return std::int32_t identifier found, or -1 if none found
      */
     static long find_system_id(const std::string& name, const std::string& file);
 
 
     /// adminisitrator or root user identifier
-    static const int16_t         ADMIN_USER_ID;
+    static const std::int16_t         ADMIN_USER_ID;
 
     /// mutex used to prevent multiple threads from corrupting user id
     static std::mutex                 m_mutex;
 
     /// primary logging interface used by this class        
-    logger                              m_logger;
+    logger                            m_logger;
 
     /// lock used to prevent multiple threads from corrupting user id
-    std::unique_lock<std::mutex>    m_lock;
+    std::unique_lock<std::mutex>      m_lock;
 
     /// saved user identifier before upgrading to administrator
-    int16_t                      m_user_id;
+    std::int16_t                      m_user_id;
 
     /// true if the class currently holds administrative rights
-    bool                                m_has_rights;
+    bool                              m_has_rights;
 
     /// if false, then no logging will be performed
-    bool                                m_use_log;
+    bool                              m_use_log;
 };
 
 

--- a/include/pion/admin_rights.hpp
+++ b/include/pion/admin_rights.hpp
@@ -53,7 +53,7 @@ private:
      * @param name descriptive name to lookup (user or group name, may be id)
      * @param file system credentials file to look within
      *
-     * @return boost::int32_t identifier found, or -1 if none found
+     * @return int32_t identifier found, or -1 if none found
      */
     static long find_system_id(const std::string& name, const std::string& file);
 

--- a/include/pion/algorithm.hpp
+++ b/include/pion/algorithm.hpp
@@ -58,82 +58,82 @@ struct PION_API algorithm {
     static void float_to_bytes(long double value, unsigned char *ptr, size_t num_exp_bits, size_t num_fraction_bits);
 
     /// convert sequence of one byte to 8-bit unsigned integer
-    static inline uint8_t to_uint8(unsigned char byte) {
-        return uint8_t(byte);
+    static inline std::uint8_t to_uint8(unsigned char byte) {
+        return std::uint8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit signed integer
-    static inline int8_t to_int8(unsigned char byte) {
-        return int8_t(byte);
+    static inline std::int8_t to_int8(unsigned char byte) {
+        return std::int8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit unsigned integer
-    static inline uint8_t to_uint8(char byte) {
-        return uint8_t(byte);
+    static inline std::uint8_t to_uint8(char byte) {
+        return std::uint8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit signed integer
-    static inline int8_t to_int8(char byte) {
-        return int8_t(byte);
+    static inline std::int8_t to_int8(char byte) {
+        return std::int8_t(byte);
     }
     
     /// convert sequence of two bytes to 16-bit unsigned integer
-    static inline uint16_t to_uint16(unsigned char high, unsigned char low) {
-        return (((uint16_t)high) << 8) | ((uint16_t)low);
+    static inline std::uint16_t to_uint16(unsigned char high, unsigned char low) {
+        return (((std::uint16_t)high) << 8) | ((std::uint16_t)low);
     }
 
     /// convert sequence of two bytes to 16-bit signed integer
-    static inline int16_t to_int16(unsigned char high, unsigned char low) {
-        return (((int16_t)high) << 8) | ((int16_t)low);
+    static inline std::int16_t to_int16(unsigned char high, unsigned char low) {
+        return (((std::int16_t)high) << 8) | ((std::int16_t)low);
     }
 
     /// convert sequence of three bytes to 24-bit unsigned integer
-    static inline uint32_t to_uint24(unsigned char high, unsigned char mid, unsigned char low) {
-        return (((uint32_t)high) << 16) | (((uint32_t)mid) << 8) | ((uint32_t)low);
+    static inline std::uint32_t to_uint24(unsigned char high, unsigned char mid, unsigned char low) {
+        return (((std::uint32_t)high) << 16) | (((std::uint32_t)mid) << 8) | ((std::uint32_t)low);
     }
     
     /// convert sequence of three bytes to 24-bit signed integer
-    static inline int32_t to_int24(unsigned char high, unsigned char mid, unsigned char low) {
-        return (((int32_t)high) << 16) | (((int32_t)mid) << 8) | ((int32_t)low);
+    static inline std::int32_t to_int24(unsigned char high, unsigned char mid, unsigned char low) {
+        return (((std::int32_t)high) << 16) | (((std::int32_t)mid) << 8) | ((std::int32_t)low);
     }
     
     /// convert sequence of four bytes to 32-bit unsigned integer
-    static inline uint32_t to_uint32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
-        return (((uint32_t)high) << 24) | (((int32_t)mid1) << 16) | (((int32_t)mid2) << 8) | ((int32_t)low);
+    static inline std::uint32_t to_uint32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
+        return (((std::uint32_t)high) << 24) | (((std::int32_t)mid1) << 16) | (((std::int32_t)mid2) << 8) | ((std::int32_t)low);
     }
     
     /// convert sequence of four bytes to 32-bit signed integer
-    static inline int32_t to_int32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
-        return (((int32_t)high) << 24) | (((int32_t)mid1) << 16) | (((int32_t)mid2) << 8) | ((int32_t)low);
+    static inline std::int32_t to_int32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
+        return (((std::int32_t)high) << 24) | (((std::int32_t)mid1) << 16) | (((std::int32_t)mid2) << 8) | ((std::int32_t)low);
     }
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
-    static inline uint64_t to_uint64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
-        return (((int64_t)high) << 56) | (((int64_t)mid1) << 48) | (((int64_t)mid2) << 40) | (((int64_t)mid3) << 32)
-            | (((int64_t)mid4) << 24) | (((int64_t)mid5) << 16) | (((int64_t)mid6) << 8) | ((int64_t)low);
+    static inline std::uint64_t to_uint64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
+        return (((std::int64_t)high) << 56) | (((std::int64_t)mid1) << 48) | (((std::int64_t)mid2) << 40) | (((std::int64_t)mid3) << 32)
+            | (((std::int64_t)mid4) << 24) | (((std::int64_t)mid5) << 16) | (((std::int64_t)mid6) << 8) | ((std::int64_t)low);
     }
     
     /// convert sequence of eight bytes to 64-bit signed integer
-    static inline int64_t to_int64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
-        return (((int64_t)high) << 56) | (((int64_t)mid1) << 48) | (((int64_t)mid2) << 40) | (((int64_t)mid3) << 32)
-        | (((int64_t)mid4) << 24) | (((int64_t)mid5) << 16) | (((int64_t)mid6) << 8) | ((int64_t)low);
+    static inline std::int64_t to_int64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
+        return (((std::int64_t)high) << 56) | (((std::int64_t)mid1) << 48) | (((std::int64_t)mid2) << 40) | (((std::int64_t)mid3) << 32)
+        | (((std::int64_t)mid4) << 24) | (((std::int64_t)mid5) << 16) | (((std::int64_t)mid6) << 8) | ((std::int64_t)low);
     }
 
     /// convert sequence of two bytes to 16-bit unsigned integer
     template <typename T1, typename T2>
-    static inline uint16_t to_uint16(T1 high, T2 low) {
+    static inline std::uint16_t to_uint16(T1 high, T2 low) {
         return to_uint16(static_cast<unsigned char>(high), static_cast<unsigned char>(low));
     }
     
     /// convert sequence of two bytes to 16-bit signed integer
     template <typename T1, typename T2>
-    static inline int16_t to_int16(T1 high, T2 low) {
+    static inline std::int16_t to_int16(T1 high, T2 low) {
         return to_int16(static_cast<unsigned char>(high), static_cast<unsigned char>(low));
     }
     
     /// convert sequence of three bytes to 24-bit unsigned integer
     template <typename T1, typename T2, typename T3>
-    static inline uint32_t to_uint24(T1 high, T2 mid, T3 low) {
+    static inline std::uint32_t to_uint24(T1 high, T2 mid, T3 low) {
         return to_uint24(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid),
                          static_cast<unsigned char>(low));
@@ -141,7 +141,7 @@ struct PION_API algorithm {
 
     /// convert sequence of three bytes to 24-bit signed integer
     template <typename T1, typename T2, typename T3>
-    static inline int32_t to_int24(T1 high, T2 mid, T3 low) {
+    static inline std::int32_t to_int24(T1 high, T2 mid, T3 low) {
         return to_int24(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid),
                         static_cast<unsigned char>(low));
@@ -149,7 +149,7 @@ struct PION_API algorithm {
     
     /// convert sequence of four bytes to 32-bit unsigned integer
     template <typename T1, typename T2, typename T3, typename T4>
-    static inline uint32_t to_uint32(T1 high, T2 mid1, T3 mid2, T4 low) {
+    static inline std::uint32_t to_uint32(T1 high, T2 mid1, T3 mid2, T4 low) {
         return to_uint32(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid1),
                          static_cast<unsigned char>(mid2),
@@ -158,7 +158,7 @@ struct PION_API algorithm {
     
     /// convert sequence of four bytes to 32-bit signed integer
     template <typename T1, typename T2, typename T3, typename T4>
-    static inline int32_t to_int32(T1 high, T2 mid1, T3 mid2, T4 low) {
+    static inline std::int32_t to_int32(T1 high, T2 mid1, T3 mid2, T4 low) {
         return to_int32(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid1),
                         static_cast<unsigned char>(mid2),
@@ -167,7 +167,7 @@ struct PION_API algorithm {
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    static inline uint64_t to_uint64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
+    static inline std::uint64_t to_uint64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
         return to_uint64(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid1),
                          static_cast<unsigned char>(mid2),
@@ -180,7 +180,7 @@ struct PION_API algorithm {
     
     /// convert sequence of eight bytes to 64-bit signed integer
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    static inline int64_t to_int64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
+    static inline std::int64_t to_int64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
         return to_int64(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid1),
                         static_cast<unsigned char>(mid2),
@@ -194,93 +194,93 @@ struct PION_API algorithm {
     
     /// convert byte pointer into an 8-bit unsigned integer
     template <typename Byte>
-    static inline uint8_t to_uint8(const Byte *buf) {
+    static inline std::uint8_t to_uint8(const Byte *buf) {
         return to_uint8(buf[0]);
     }
     
     /// convert byte pointer into an 8-bit signed integer
     template <typename Byte>
-    static inline int8_t to_int8(const Byte *buf) {
+    static inline std::int8_t to_int8(const Byte *buf) {
         return to_int8(buf[0]);
     }
     
     /// convert sequence of two bytes to 16-bit unsigned integer
     template <typename Byte>
-    static inline uint16_t to_uint16(const Byte *buf) {
+    static inline std::uint16_t to_uint16(const Byte *buf) {
         return to_uint16(buf[0], buf[1]);
     }
     
     /// convert sequence of two bytes to 16-bit signed integer
     template <typename Byte>
-    static inline int16_t to_int16(const Byte *buf) {
+    static inline std::int16_t to_int16(const Byte *buf) {
         return to_int16(buf[0], buf[1]);
     }
     
     /// convert sequence of three bytes to 24-bit unsigned integer
     template <typename Byte>
-    static inline int32_t to_uint24(const Byte *buf) {
+    static inline std::int32_t to_uint24(const Byte *buf) {
         return to_uint24(buf[0], buf[1], buf[2]);
     }
     
     /// convert sequence of three bytes to 24-bit signed integer
     template <typename Byte>
-    static inline int32_t to_int24(const Byte *buf) {
+    static inline std::int32_t to_int24(const Byte *buf) {
         return to_int24(buf[0], buf[1], buf[2]);
     }
     
     /// convert sequence of four bytes to 32-bit unsigned integer
     template <typename Byte>
-    static inline uint32_t to_uint32(const Byte *buf) {
+    static inline std::uint32_t to_uint32(const Byte *buf) {
         return to_uint32(buf[0], buf[1], buf[2], buf[3]);
     }
     
     /// convert sequence of four bytes to 32-bit signed integer
     template <typename Byte>
-    static inline int32_t to_int32(const Byte *buf) {
+    static inline std::int32_t to_int32(const Byte *buf) {
         return to_int32(buf[0], buf[1], buf[2], buf[3]);
     }
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
     template <typename Byte>
-    static inline uint64_t to_uint64(const Byte *buf) {
+    static inline std::uint64_t to_uint64(const Byte *buf) {
         return to_uint64(buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     }
     
     /// convert sequence of eight bytes to 64-bit signed integer
     template <typename Byte>
-    static inline int64_t to_int64(const Byte *buf) {
+    static inline std::int64_t to_int64(const Byte *buf) {
         return to_int64(buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     }
 
     /// convert 8-bit unsigned integer into sequence of one byte
     template <typename Byte>
-    static inline void from_uint8(Byte *buf, const uint8_t n) {
+    static inline void from_uint8(Byte *buf, const std::uint8_t n) {
         buf[0] = n & 0xFF;
     }
     
     /// convert 8-bit signed integer into sequence of one byte
     template <typename Byte>
-    static inline void from_int8(Byte *buf, const int8_t n) {
+    static inline void from_int8(Byte *buf, const std::int8_t n) {
         buf[0] = n & 0xFF;
     }
     
     /// convert 16-bit unsigned integer into sequence of two bytes
     template <typename Byte>
-    static inline void from_uint16(Byte *buf, const uint16_t n) {
+    static inline void from_uint16(Byte *buf, const std::uint16_t n) {
         buf[0] = (n >> 8) & 0xFF;
         buf[1] = n & 0xFF;
     }
 
     /// convert 16-bit signed integer into sequence of two bytes
     template <typename Byte>
-    static inline void from_int16(Byte *buf, const int16_t n) {
+    static inline void from_int16(Byte *buf, const std::int16_t n) {
         buf[0] = (n >> 8) & 0xFF;
         buf[1] = n & 0xFF;
     }
     
     /// convert 24-bit unsigned integer into sequence of three bytes
     template <typename Byte>
-    static inline void from_uint24(Byte *buf, const int32_t n) {
+    static inline void from_uint24(Byte *buf, const std::int32_t n) {
         buf[0] = (n >> 16) & 0xFF;
         buf[1] = (n >> 8) & 0xFF;
         buf[2] = n & 0xFF;
@@ -288,7 +288,7 @@ struct PION_API algorithm {
     
     /// convert 24-bit signed integer into sequence of three bytes
     template <typename Byte>
-    static inline void from_int24(Byte *buf, const int32_t n) {
+    static inline void from_int24(Byte *buf, const std::int32_t n) {
         buf[0] = (n >> 16) & 0xFF;
         buf[1] = (n >> 8) & 0xFF;
         buf[2] = n & 0xFF;
@@ -296,7 +296,7 @@ struct PION_API algorithm {
     
     /// convert 32-bit unsigned integer into sequence of four bytes
     template <typename Byte>
-    static inline void from_uint32(Byte *buf, const uint32_t n) {
+    static inline void from_uint32(Byte *buf, const std::uint32_t n) {
         buf[0] = (n >> 24) & 0xFF;
         buf[1] = (n >> 16) & 0xFF;
         buf[2] = (n >> 8) & 0xFF;
@@ -305,7 +305,7 @@ struct PION_API algorithm {
     
     /// convert 32-bit signed integer into sequence of four bytes
     template <typename Byte>
-    static inline void from_int32(Byte *buf, const int32_t n) {
+    static inline void from_int32(Byte *buf, const std::int32_t n) {
         buf[0] = (n >> 24) & 0xFF;
         buf[1] = (n >> 16) & 0xFF;
         buf[2] = (n >> 8) & 0xFF;
@@ -314,7 +314,7 @@ struct PION_API algorithm {
 
     /// convert 64-bit unsigned integer into sequence of eight bytes
     template <typename Byte>
-    static inline void from_uint64(Byte *buf, const uint64_t n) {
+    static inline void from_uint64(Byte *buf, const std::uint64_t n) {
         buf[0] = (n >> 56) & 0xFF;
         buf[1] = (n >> 48) & 0xFF;
         buf[2] = (n >> 40) & 0xFF;
@@ -327,7 +327,7 @@ struct PION_API algorithm {
     
     /// convert 64-bit signed integer into sequence of eight bytes
     template <typename Byte>
-    static inline void from_int64(Byte *buf, const int64_t n) {
+    static inline void from_int64(Byte *buf, const std::int64_t n) {
         buf[0] = (n >> 56) & 0xFF;
         buf[1] = (n >> 48) & 0xFF;
         buf[2] = (n >> 40) & 0xFF;

--- a/include/pion/algorithm.hpp
+++ b/include/pion/algorithm.hpp
@@ -11,7 +11,7 @@
 #define __PION_ALGORITHM_HEADER__
 
 #include <string>
-#include <boost/cstdint.hpp>
+
 #include <pion/config.hpp>
 
 namespace pion {    // begin namespace pion
@@ -58,90 +58,90 @@ struct PION_API algorithm {
     static void float_to_bytes(long double value, unsigned char *ptr, size_t num_exp_bits, size_t num_fraction_bits);
 
     /// convert sequence of one byte to 8-bit unsigned integer
-    static inline boost::uint8_t to_uint8(unsigned char byte) {
-        return boost::uint8_t(byte);
+    static inline uint8_t to_uint8(unsigned char byte) {
+        return uint8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit signed integer
-    static inline boost::int8_t to_int8(unsigned char byte) {
-        return boost::int8_t(byte);
+    static inline int8_t to_int8(unsigned char byte) {
+        return int8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit unsigned integer
-    static inline boost::uint8_t to_uint8(char byte) {
-        return boost::uint8_t(byte);
+    static inline uint8_t to_uint8(char byte) {
+        return uint8_t(byte);
     }
     
     /// convert sequence of one byte to 8-bit signed integer
-    static inline boost::int8_t to_int8(char byte) {
-        return boost::int8_t(byte);
+    static inline int8_t to_int8(char byte) {
+        return int8_t(byte);
     }
     
     /// convert sequence of two bytes to 16-bit unsigned integer
-    static inline boost::uint16_t to_uint16(unsigned char high, unsigned char low) {
-        return (((boost::uint16_t)high) << 8) | ((boost::uint16_t)low);
+    static inline uint16_t to_uint16(unsigned char high, unsigned char low) {
+        return (((uint16_t)high) << 8) | ((uint16_t)low);
     }
 
     /// convert sequence of two bytes to 16-bit signed integer
-    static inline boost::int16_t to_int16(unsigned char high, unsigned char low) {
-        return (((boost::int16_t)high) << 8) | ((boost::int16_t)low);
+    static inline int16_t to_int16(unsigned char high, unsigned char low) {
+        return (((int16_t)high) << 8) | ((int16_t)low);
     }
 
     /// convert sequence of three bytes to 24-bit unsigned integer
-    static inline boost::uint32_t to_uint24(unsigned char high, unsigned char mid, unsigned char low) {
-        return (((boost::uint32_t)high) << 16) | (((boost::uint32_t)mid) << 8) | ((boost::uint32_t)low);
+    static inline uint32_t to_uint24(unsigned char high, unsigned char mid, unsigned char low) {
+        return (((uint32_t)high) << 16) | (((uint32_t)mid) << 8) | ((uint32_t)low);
     }
     
     /// convert sequence of three bytes to 24-bit signed integer
-    static inline boost::int32_t to_int24(unsigned char high, unsigned char mid, unsigned char low) {
-        return (((boost::int32_t)high) << 16) | (((boost::int32_t)mid) << 8) | ((boost::int32_t)low);
+    static inline int32_t to_int24(unsigned char high, unsigned char mid, unsigned char low) {
+        return (((int32_t)high) << 16) | (((int32_t)mid) << 8) | ((int32_t)low);
     }
     
     /// convert sequence of four bytes to 32-bit unsigned integer
-    static inline boost::uint32_t to_uint32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
-        return (((boost::uint32_t)high) << 24) | (((boost::uint32_t)mid1) << 16) | (((boost::uint32_t)mid2) << 8) | ((boost::uint32_t)low);
+    static inline uint32_t to_uint32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
+        return (((uint32_t)high) << 24) | (((int32_t)mid1) << 16) | (((int32_t)mid2) << 8) | ((int32_t)low);
     }
     
     /// convert sequence of four bytes to 32-bit signed integer
-    static inline boost::int32_t to_int32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
-        return (((boost::int32_t)high) << 24) | (((boost::int32_t)mid1) << 16) | (((boost::int32_t)mid2) << 8) | ((boost::int32_t)low);
+    static inline int32_t to_int32(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char low) {
+        return (((int32_t)high) << 24) | (((int32_t)mid1) << 16) | (((int32_t)mid2) << 8) | ((int32_t)low);
     }
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
-    static inline boost::uint64_t to_uint64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
-        return (((boost::uint64_t)high) << 56) | (((boost::uint64_t)mid1) << 48) | (((boost::uint64_t)mid2) << 40) | (((boost::uint64_t)mid3) << 32)
-            | (((boost::uint64_t)mid4) << 24) | (((boost::uint64_t)mid5) << 16) | (((boost::uint64_t)mid6) << 8) | ((boost::uint64_t)low);
+    static inline uint64_t to_uint64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
+        return (((int64_t)high) << 56) | (((int64_t)mid1) << 48) | (((int64_t)mid2) << 40) | (((int64_t)mid3) << 32)
+            | (((int64_t)mid4) << 24) | (((int64_t)mid5) << 16) | (((int64_t)mid6) << 8) | ((int64_t)low);
     }
     
     /// convert sequence of eight bytes to 64-bit signed integer
-    static inline boost::int64_t to_int64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
-        return (((boost::int64_t)high) << 56) | (((boost::int64_t)mid1) << 48) | (((boost::int64_t)mid2) << 40) | (((boost::int64_t)mid3) << 32)
-        | (((boost::int64_t)mid4) << 24) | (((boost::int64_t)mid5) << 16) | (((boost::int64_t)mid6) << 8) | ((boost::int64_t)low);
+    static inline int64_t to_int64(unsigned char high, unsigned char mid1, unsigned char mid2, unsigned char mid3, unsigned char mid4, unsigned char mid5, unsigned char mid6, unsigned char low) {
+        return (((int64_t)high) << 56) | (((int64_t)mid1) << 48) | (((int64_t)mid2) << 40) | (((int64_t)mid3) << 32)
+        | (((int64_t)mid4) << 24) | (((int64_t)mid5) << 16) | (((int64_t)mid6) << 8) | ((int64_t)low);
     }
 
     /// convert sequence of two bytes to 16-bit unsigned integer
     template <typename T1, typename T2>
-    static inline boost::uint16_t to_uint16(T1 high, T2 low) {
+    static inline uint16_t to_uint16(T1 high, T2 low) {
         return to_uint16(static_cast<unsigned char>(high), static_cast<unsigned char>(low));
     }
     
     /// convert sequence of two bytes to 16-bit signed integer
     template <typename T1, typename T2>
-    static inline boost::int16_t to_int16(T1 high, T2 low) {
+    static inline int16_t to_int16(T1 high, T2 low) {
         return to_int16(static_cast<unsigned char>(high), static_cast<unsigned char>(low));
     }
     
     /// convert sequence of three bytes to 24-bit unsigned integer
     template <typename T1, typename T2, typename T3>
-    static inline boost::uint32_t to_uint24(T1 high, T2 mid, T3 low) {
+    static inline uint32_t to_uint24(T1 high, T2 mid, T3 low) {
         return to_uint24(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid),
                          static_cast<unsigned char>(low));
     }
-    
+
     /// convert sequence of three bytes to 24-bit signed integer
     template <typename T1, typename T2, typename T3>
-    static inline boost::int32_t to_int24(T1 high, T2 mid, T3 low) {
+    static inline int32_t to_int24(T1 high, T2 mid, T3 low) {
         return to_int24(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid),
                         static_cast<unsigned char>(low));
@@ -149,7 +149,7 @@ struct PION_API algorithm {
     
     /// convert sequence of four bytes to 32-bit unsigned integer
     template <typename T1, typename T2, typename T3, typename T4>
-    static inline boost::uint32_t to_uint32(T1 high, T2 mid1, T3 mid2, T4 low) {
+    static inline uint32_t to_uint32(T1 high, T2 mid1, T3 mid2, T4 low) {
         return to_uint32(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid1),
                          static_cast<unsigned char>(mid2),
@@ -158,7 +158,7 @@ struct PION_API algorithm {
     
     /// convert sequence of four bytes to 32-bit signed integer
     template <typename T1, typename T2, typename T3, typename T4>
-    static inline boost::int32_t to_int32(T1 high, T2 mid1, T3 mid2, T4 low) {
+    static inline int32_t to_int32(T1 high, T2 mid1, T3 mid2, T4 low) {
         return to_int32(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid1),
                         static_cast<unsigned char>(mid2),
@@ -167,7 +167,7 @@ struct PION_API algorithm {
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    static inline boost::uint64_t to_uint64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
+    static inline uint64_t to_uint64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
         return to_uint64(static_cast<unsigned char>(high),
                          static_cast<unsigned char>(mid1),
                          static_cast<unsigned char>(mid2),
@@ -180,7 +180,7 @@ struct PION_API algorithm {
     
     /// convert sequence of eight bytes to 64-bit signed integer
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    static inline boost::int64_t to_int64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
+    static inline int64_t to_int64(T1 high, T2 mid1, T3 mid2, T4 mid3, T5 mid4, T6 mid5, T7 mid6, T8 low) {
         return to_int64(static_cast<unsigned char>(high),
                         static_cast<unsigned char>(mid1),
                         static_cast<unsigned char>(mid2),
@@ -194,93 +194,93 @@ struct PION_API algorithm {
     
     /// convert byte pointer into an 8-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint8_t to_uint8(const Byte *buf) {
+    static inline uint8_t to_uint8(const Byte *buf) {
         return to_uint8(buf[0]);
     }
     
     /// convert byte pointer into an 8-bit signed integer
     template <typename Byte>
-    static inline boost::int8_t to_int8(const Byte *buf) {
+    static inline int8_t to_int8(const Byte *buf) {
         return to_int8(buf[0]);
     }
     
     /// convert sequence of two bytes to 16-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint16_t to_uint16(const Byte *buf) {
+    static inline uint16_t to_uint16(const Byte *buf) {
         return to_uint16(buf[0], buf[1]);
     }
     
     /// convert sequence of two bytes to 16-bit signed integer
     template <typename Byte>
-    static inline boost::int16_t to_int16(const Byte *buf) {
+    static inline int16_t to_int16(const Byte *buf) {
         return to_int16(buf[0], buf[1]);
     }
     
     /// convert sequence of three bytes to 24-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint32_t to_uint24(const Byte *buf) {
+    static inline int32_t to_uint24(const Byte *buf) {
         return to_uint24(buf[0], buf[1], buf[2]);
     }
     
     /// convert sequence of three bytes to 24-bit signed integer
     template <typename Byte>
-    static inline boost::int32_t to_int24(const Byte *buf) {
+    static inline int32_t to_int24(const Byte *buf) {
         return to_int24(buf[0], buf[1], buf[2]);
     }
     
     /// convert sequence of four bytes to 32-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint32_t to_uint32(const Byte *buf) {
+    static inline uint32_t to_uint32(const Byte *buf) {
         return to_uint32(buf[0], buf[1], buf[2], buf[3]);
     }
     
     /// convert sequence of four bytes to 32-bit signed integer
     template <typename Byte>
-    static inline boost::int32_t to_int32(const Byte *buf) {
+    static inline int32_t to_int32(const Byte *buf) {
         return to_int32(buf[0], buf[1], buf[2], buf[3]);
     }
     
     /// convert sequence of eight bytes to 64-bit unsigned integer
     template <typename Byte>
-    static inline boost::uint64_t to_uint64(const Byte *buf) {
+    static inline uint64_t to_uint64(const Byte *buf) {
         return to_uint64(buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     }
     
     /// convert sequence of eight bytes to 64-bit signed integer
     template <typename Byte>
-    static inline boost::int64_t to_int64(const Byte *buf) {
+    static inline int64_t to_int64(const Byte *buf) {
         return to_int64(buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
     }
 
     /// convert 8-bit unsigned integer into sequence of one byte
     template <typename Byte>
-    static inline void from_uint8(Byte *buf, const boost::uint8_t n) {
+    static inline void from_uint8(Byte *buf, const uint8_t n) {
         buf[0] = n & 0xFF;
     }
     
     /// convert 8-bit signed integer into sequence of one byte
     template <typename Byte>
-    static inline void from_int8(Byte *buf, const boost::int8_t n) {
+    static inline void from_int8(Byte *buf, const int8_t n) {
         buf[0] = n & 0xFF;
     }
     
     /// convert 16-bit unsigned integer into sequence of two bytes
     template <typename Byte>
-    static inline void from_uint16(Byte *buf, const boost::uint16_t n) {
+    static inline void from_uint16(Byte *buf, const uint16_t n) {
         buf[0] = (n >> 8) & 0xFF;
         buf[1] = n & 0xFF;
     }
 
     /// convert 16-bit signed integer into sequence of two bytes
     template <typename Byte>
-    static inline void from_int16(Byte *buf, const boost::int16_t n) {
+    static inline void from_int16(Byte *buf, const int16_t n) {
         buf[0] = (n >> 8) & 0xFF;
         buf[1] = n & 0xFF;
     }
     
     /// convert 24-bit unsigned integer into sequence of three bytes
     template <typename Byte>
-    static inline void from_uint24(Byte *buf, const boost::uint32_t n) {
+    static inline void from_uint24(Byte *buf, const int32_t n) {
         buf[0] = (n >> 16) & 0xFF;
         buf[1] = (n >> 8) & 0xFF;
         buf[2] = n & 0xFF;
@@ -288,7 +288,7 @@ struct PION_API algorithm {
     
     /// convert 24-bit signed integer into sequence of three bytes
     template <typename Byte>
-    static inline void from_int24(Byte *buf, const boost::int32_t n) {
+    static inline void from_int24(Byte *buf, const int32_t n) {
         buf[0] = (n >> 16) & 0xFF;
         buf[1] = (n >> 8) & 0xFF;
         buf[2] = n & 0xFF;
@@ -296,7 +296,7 @@ struct PION_API algorithm {
     
     /// convert 32-bit unsigned integer into sequence of four bytes
     template <typename Byte>
-    static inline void from_uint32(Byte *buf, const boost::uint32_t n) {
+    static inline void from_uint32(Byte *buf, const uint32_t n) {
         buf[0] = (n >> 24) & 0xFF;
         buf[1] = (n >> 16) & 0xFF;
         buf[2] = (n >> 8) & 0xFF;
@@ -305,7 +305,7 @@ struct PION_API algorithm {
     
     /// convert 32-bit signed integer into sequence of four bytes
     template <typename Byte>
-    static inline void from_int32(Byte *buf, const boost::int32_t n) {
+    static inline void from_int32(Byte *buf, const int32_t n) {
         buf[0] = (n >> 24) & 0xFF;
         buf[1] = (n >> 16) & 0xFF;
         buf[2] = (n >> 8) & 0xFF;
@@ -314,7 +314,7 @@ struct PION_API algorithm {
 
     /// convert 64-bit unsigned integer into sequence of eight bytes
     template <typename Byte>
-    static inline void from_uint64(Byte *buf, const boost::uint64_t n) {
+    static inline void from_uint64(Byte *buf, const uint64_t n) {
         buf[0] = (n >> 56) & 0xFF;
         buf[1] = (n >> 48) & 0xFF;
         buf[2] = (n >> 40) & 0xFF;
@@ -327,7 +327,7 @@ struct PION_API algorithm {
     
     /// convert 64-bit signed integer into sequence of eight bytes
     template <typename Byte>
-    static inline void from_int64(Byte *buf, const boost::int64_t n) {
+    static inline void from_int64(Byte *buf, const int64_t n) {
         buf[0] = (n >> 56) & 0xFF;
         buf[1] = (n >> 48) & 0xFF;
         buf[2] = (n >> 40) & 0xFF;

--- a/include/pion/hash_map.hpp
+++ b/include/pion/hash_map.hpp
@@ -34,8 +34,8 @@ namespace pion {    // begin namespace pion
 #if defined(PION_HAVE_UNORDERED_MAP)
     #define PION_HASH_MAP std::unordered_map
     #define PION_HASH_MULTIMAP std::unordered_multimap
-    #define PION_HASH_STRING boost::hash<std::string>
-    #define PION_HASH(TYPE) boost::hash<TYPE>
+    #define PION_HASH_STRING std::hash<std::string>
+    #define PION_HASH(TYPE) std::hash<TYPE>
 #elif defined(PION_HAVE_TR1_UNORDERED_MAP)
     #define PION_HASH_MAP std::tr1::unordered_map
     #define PION_HASH_MULTIMAP std::tr1::unordered_multimap

--- a/include/pion/http/auth.hpp
+++ b/include/pion/http/auth.hpp
@@ -162,7 +162,7 @@ protected:
     resource_set_type       m_white_list;
 
     /// mutex used to protect access to the resources
-    mutable boost::mutex    m_resource_mutex;
+    mutable std::mutex    m_resource_mutex;
 };
 
 /// data type for a auth pointer

--- a/include/pion/http/auth.hpp
+++ b/include/pion/http/auth.hpp
@@ -12,8 +12,8 @@
 
 #include <set>
 #include <map>
+#include <memory>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/logger.hpp>
@@ -166,7 +166,7 @@ protected:
 };
 
 /// data type for a auth pointer
-typedef boost::shared_ptr<auth> auth_ptr;
+typedef std::shared_ptr<auth> auth_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/basic_auth.hpp
+++ b/include/pion/http/basic_auth.hpp
@@ -98,7 +98,7 @@ private:
     user_cache_type             m_user_cache;
     
     /// mutex used to protect access to the user cache
-    mutable boost::mutex        m_cache_mutex;
+    mutable std::mutex        m_cache_mutex;
 };
 
     

--- a/include/pion/http/cookie_auth.hpp
+++ b/include/pion/http/cookie_auth.hpp
@@ -171,7 +171,7 @@ private:
     user_cache_type             m_user_cache;
     
     /// mutex used to protect access to the user cache
-    mutable boost::mutex        m_cache_mutex;
+    mutable std::mutex        m_cache_mutex;
 };
 
     

--- a/include/pion/http/cookie_auth.hpp
+++ b/include/pion/http/cookie_auth.hpp
@@ -15,10 +15,10 @@
 // #pragma diagnostic is only supported by GCC >= 4.2.1
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2) || (__GNUC__ == 4 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ >= 1)
     #pragma GCC diagnostic ignored "-Wunused-parameter"
-    #include <boost/random.hpp>
+    #include <random>
     #pragma GCC diagnostic warning "-Wunused-parameter"
 #else
-    #include <boost/random.hpp>
+    #include <random>
 #endif
 #include <pion/config.hpp>
 #include <pion/http/auth.hpp>
@@ -156,13 +156,13 @@ private:
     std::string                 m_redirect;
     
     /// random number generator used for cookie generation
-    boost::mt19937              m_random_gen;
+    std::mt19937                m_random_gen;
 
     /// random number range used for cookie generation
-    boost::uniform_int<>        m_random_range;
+    std::uniform_int_distribution<>        m_random_range;
 
     /// random dice that uses m_random_gen to produce ints within m_random_range
-    boost::variate_generator<boost::mt19937&, boost::uniform_int<> >    m_random_die;
+    std::function<std::uniform_int_distribution<>::result_type ()>    m_random_die;
 
     /// time of the last cache clean up
     boost::posix_time::ptime    m_cache_cleanup_time;
@@ -171,7 +171,7 @@ private:
     user_cache_type             m_user_cache;
     
     /// mutex used to protect access to the user cache
-    mutable std::mutex        m_cache_mutex;
+    mutable std::mutex          m_cache_mutex;
 };
 
     

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -14,10 +14,10 @@
 #include <vector>
 #include <cstring>
 #include <cstdint>
+#include <regex>
 #include <asio.hpp>
 #include <boost/scoped_array.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/regex.hpp>
 #include <pion/config.hpp>
 #include <pion/http/types.hpp>
 #include <boost/system/error_code.hpp>
@@ -331,7 +331,7 @@ public:
         ihash_multimap::const_iterator i = m_headers.find(HEADER_TRANSFER_ENCODING);
         if (i != m_headers.end()) {
             // From RFC 2616, sec 3.6: All transfer-coding values are case-insensitive.
-            m_is_chunked = boost::regex_match(i->second, REGEX_ICASE_CHUNKED);
+            m_is_chunked = std::regex_match(i->second, REGEX_ICASE_CHUNKED);
             // ignoring other possible values for now
         }
     }
@@ -684,7 +684,7 @@ protected:
 private:
 
     /// Regex used to check for the "chunked" transfer encoding header
-    static const boost::regex       REGEX_ICASE_CHUNKED;
+    static const std::regex       REGEX_ICASE_CHUNKED;
 
     /// True if the HTTP message is valid
     bool                            m_is_valid;

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -290,13 +290,13 @@ public:
     inline void set_remote_ip(const asio::ip::address& ip) { m_remote_ip = ip; }
 
     /// sets the major HTTP version number
-    inline void set_version_major(const boost::uint16_t n) {
+    inline void set_version_major(const uint16_t n) {
         m_version_major = n;
         clear_first_line();
     }
 
     /// sets the minor HTTP version number
-    inline void set_version_minor(const boost::uint16_t n) {
+    inline void set_version_minor(const uint16_t n) {
         m_version_minor = n;
         clear_first_line();
     }

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -176,10 +176,10 @@ public:
     }
 
     /// returns the major HTTP version number
-    inline uint16_t get_version_major(void) const { return m_version_major; }
+    inline std::uint16_t get_version_major(void) const { return m_version_major; }
 
     /// returns the minor HTTP version number
-    inline uint16_t get_version_minor(void) const { return m_version_minor; }
+    inline std::uint16_t get_version_minor(void) const { return m_version_minor; }
 
     /// returns a string representation of the HTTP version (i.e. "HTTP/1.1")
     inline std::string get_version_string(void) const {
@@ -289,13 +289,13 @@ public:
     inline void set_remote_ip(const asio::ip::address& ip) { m_remote_ip = ip; }
 
     /// sets the major HTTP version number
-    inline void set_version_major(const uint16_t n) {
+    inline void set_version_major(const std::uint16_t n) {
         m_version_major = n;
         clear_first_line();
     }
 
     /// sets the minor HTTP version number
-    inline void set_version_minor(const uint16_t n) {
+    inline void set_version_minor(const std::uint16_t n) {
         m_version_minor = n;
         clear_first_line();
     }
@@ -701,10 +701,10 @@ private:
     asio::ip::address        m_remote_ip;
 
     /// HTTP major version number
-    uint16_t                 m_version_major;
+    std::uint16_t                 m_version_major;
 
     /// HTTP major version number
-    uint16_t                 m_version_minor;
+    std::uint16_t                 m_version_minor;
 
     /// the length of the payload content (in bytes)
     size_t                          m_content_length;

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <regex>
 #include <asio.hpp>
-#include <boost/scoped_array.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <pion/config.hpp>
 #include <pion/http/types.hpp>
@@ -556,7 +555,7 @@ protected:
         inline void clear() { resize(0); }
         
     private:
-        boost::scoped_array<char>   m_buf;
+        std::unique_ptr<char[]>     m_buf;
         std::size_t                 m_len;
         char                        m_empty;
         char                        *m_ptr;

--- a/include/pion/http/message.hpp
+++ b/include/pion/http/message.hpp
@@ -13,14 +13,14 @@
 #include <iosfwd>
 #include <vector>
 #include <cstring>
-#include <boost/cstdint.hpp>
-#include <boost/asio.hpp>
+#include <cstdint>
+#include <asio.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/regex.hpp>
 #include <pion/config.hpp>
 #include <pion/http/types.hpp>
+#include <boost/system/error_code.hpp>
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
     // if 'BOOST_NOEXCEPT' is not defined, as with some older versions of
@@ -58,7 +58,7 @@ class PION_API message
 public:
 
     /// data type for I/O write buffers (these wrap existing data to be sent)
-    typedef std::vector<boost::asio::const_buffer>  write_buffers_t;
+    typedef std::vector<asio::const_buffer>  write_buffers_t;
 
     /// used to cache chunked data
     typedef std::vector<char>   chunk_cache_t;
@@ -150,7 +150,7 @@ public:
         clear_first_line();
         m_is_valid = m_is_chunked = m_chunks_supported
             = m_do_not_send_content_length = false;
-        m_remote_ip = boost::asio::ip::address_v4(0);
+        m_remote_ip = asio::ip::address_v4(0);
         m_version_major = m_version_minor = 1;
         m_content_length = 0;
         m_content_buf.clear();
@@ -172,22 +172,22 @@ public:
     inline bool get_chunks_supported(void) const { return m_chunks_supported; }
 
     /// returns IP address of the remote endpoint
-    inline boost::asio::ip::address& get_remote_ip(void) {
+    inline asio::ip::address& get_remote_ip(void) {
         return m_remote_ip;
     }
 
     /// returns the major HTTP version number
-    inline boost::uint16_t get_version_major(void) const { return m_version_major; }
+    inline uint16_t get_version_major(void) const { return m_version_major; }
 
     /// returns the minor HTTP version number
-    inline boost::uint16_t get_version_minor(void) const { return m_version_minor; }
+    inline uint16_t get_version_minor(void) const { return m_version_minor; }
 
     /// returns a string representation of the HTTP version (i.e. "HTTP/1.1")
     inline std::string get_version_string(void) const {
         std::string http_version(STRING_HTTP_VERSION);
-        http_version += boost::lexical_cast<std::string>(get_version_major());
+        http_version += std::to_string(get_version_major());
         http_version += '.';
-        http_version += boost::lexical_cast<std::string>(get_version_minor());
+        http_version += std::to_string(get_version_minor());
         return http_version;
     }
 
@@ -287,7 +287,7 @@ public:
     inline void set_chunks_supported(bool b) { m_chunks_supported = b; }
 
     /// sets IP address of the remote endpoint
-    inline void set_remote_ip(const boost::asio::ip::address& ip) { m_remote_ip = ip; }
+    inline void set_remote_ip(const asio::ip::address& ip) { m_remote_ip = ip; }
 
     /// sets the major HTTP version number
     inline void set_version_major(const boost::uint16_t n) {
@@ -321,7 +321,7 @@ public:
         } else {
             std::string trimmed_length(i->second);
             boost::algorithm::trim(trimmed_length);
-            m_content_length = boost::lexical_cast<size_t>(trimmed_length);
+            m_content_length = std::stoul(trimmed_length);
         }
     }
 
@@ -398,8 +398,8 @@ public:
         // update message headers
         prepare_headers_for_send(keep_alive, using_chunks);
         // add first message line
-        write_buffers.push_back(boost::asio::buffer(get_first_line()));
-        write_buffers.push_back(boost::asio::buffer(STRING_CRLF));
+        write_buffers.push_back(asio::buffer(get_first_line()));
+        write_buffers.push_back(asio::buffer(STRING_CRLF));
         // append cookie headers (if any)
         append_cookie_headers();
         // append HTTP headers
@@ -417,7 +417,7 @@ public:
      * @return std::size_t number of bytes written to the connection
      */
     std::size_t send(tcp::connection& tcp_conn,
-                     boost::system::error_code& ec,
+                     asio::error_code& ec,
                      bool headers_only = false);
 
     /**
@@ -430,7 +430,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t receive(tcp::connection& tcp_conn,
-                        boost::system::error_code& ec,
+                        asio::error_code& ec,
                         parser& http_parser);
     
     /**
@@ -444,7 +444,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t receive(tcp::connection& tcp_conn,
-                        boost::system::error_code& ec,
+                        asio::error_code& ec,
                         bool headers_only = false,
                         std::size_t max_content_length = static_cast<size_t>(-1));
 
@@ -458,7 +458,7 @@ public:
      * @return std::size_t number of bytes written to the connection
      */
     std::size_t write(std::ostream& out,
-                      boost::system::error_code& ec,
+                      asio::error_code& ec,
                       bool headers_only = false);
 
     /**
@@ -471,7 +471,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t read(std::istream& in,
-                     boost::system::error_code& ec,
+                     asio::error_code& ec,
                      parser& http_parser);
     
     /**
@@ -485,7 +485,7 @@ public:
      * @return std::size_t number of bytes read from the connection
      */
     std::size_t read(std::istream& in,
-                     boost::system::error_code& ec,
+                     asio::error_code& ec,
                      bool headers_only = false,
                      std::size_t max_content_length = static_cast<size_t>(-1));
 
@@ -576,7 +576,7 @@ protected:
             if (get_chunks_supported())
                 change_header(HEADER_TRANSFER_ENCODING, "chunked");
         } else if (! m_do_not_send_content_length) {
-            change_header(HEADER_CONTENT_LENGTH, boost::lexical_cast<std::string>(get_content_length()));
+            change_header(HEADER_CONTENT_LENGTH, std::to_string(get_content_length()));
         }
     }
 
@@ -588,13 +588,13 @@ protected:
     inline void append_headers(write_buffers_t& write_buffers) {
         // add HTTP headers
         for (ihash_multimap::const_iterator i = m_headers.begin(); i != m_headers.end(); ++i) {
-            write_buffers.push_back(boost::asio::buffer(i->first));
-            write_buffers.push_back(boost::asio::buffer(HEADER_NAME_VALUE_DELIMITER));
-            write_buffers.push_back(boost::asio::buffer(i->second));
-            write_buffers.push_back(boost::asio::buffer(STRING_CRLF));
+            write_buffers.push_back(asio::buffer(i->first));
+            write_buffers.push_back(asio::buffer(HEADER_NAME_VALUE_DELIMITER));
+            write_buffers.push_back(asio::buffer(i->second));
+            write_buffers.push_back(asio::buffer(STRING_CRLF));
         }
         // add an extra CRLF to end HTTP headers
-        write_buffers.push_back(boost::asio::buffer(STRING_CRLF));
+        write_buffers.push_back(asio::buffer(STRING_CRLF));
     }
 
     /// appends HTTP headers for any cookies defined by the http::message
@@ -699,13 +699,13 @@ private:
     bool                            m_do_not_send_content_length;
 
     /// IP address of the remote endpoint
-    boost::asio::ip::address        m_remote_ip;
+    asio::ip::address        m_remote_ip;
 
     /// HTTP major version number
-    boost::uint16_t                 m_version_major;
+    uint16_t                 m_version_major;
 
     /// HTTP major version number
-    boost::uint16_t                 m_version_minor;
+    uint16_t                 m_version_minor;
 
     /// the length of the payload content (in bytes)
     size_t                          m_content_length;

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -311,7 +311,7 @@ public:
      * @return true if the URI was successfully parsed, false if there was an error
      */
     static bool parse_uri(const std::string& uri, std::string& proto, 
-                         std::string& host, boost::uint16_t& port, std::string& path,
+                         std::string& host, uint16_t& port, std::string& path,
                          std::string& query);
 
     /**
@@ -532,7 +532,7 @@ protected:
 
 
     /// maximum length for response status message
-    static const boost::uint32_t        STATUS_MESSAGE_MAX;
+    static const uint32_t        STATUS_MESSAGE_MAX;
 
     /// maximum length for the request method
     static const uint32_t        METHOD_MAX;

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <boost/noncopyable.hpp>
-#include <boost/function/function2.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/thread/once.hpp>

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -311,7 +311,7 @@ public:
      * @return true if the URI was successfully parsed, false if there was an error
      */
     static bool parse_uri(const std::string& uri, std::string& proto, 
-                         std::string& host, uint16_t& port, std::string& path,
+                         std::string& host, std::uint16_t& port, std::string& path,
                          std::string& query);
 
     /**
@@ -532,34 +532,34 @@ protected:
 
 
     /// maximum length for response status message
-    static const uint32_t        STATUS_MESSAGE_MAX;
+    static const std::uint32_t        STATUS_MESSAGE_MAX;
 
     /// maximum length for the request method
-    static const uint32_t        METHOD_MAX;
+    static const std::uint32_t        METHOD_MAX;
 
     /// maximum length for the resource requested
-    static const uint32_t        RESOURCE_MAX;
+    static const std::uint32_t        RESOURCE_MAX;
 
     /// maximum length for the query string
-    static const uint32_t        QUERY_STRING_MAX;
+    static const std::uint32_t        QUERY_STRING_MAX;
 
     /// maximum length for an HTTP header name
-    static const uint32_t        HEADER_NAME_MAX;
+    static const std::uint32_t        HEADER_NAME_MAX;
 
     /// maximum length for an HTTP header value
-    static const uint32_t        HEADER_VALUE_MAX;
+    static const std::uint32_t        HEADER_VALUE_MAX;
 
     /// maximum length for the name of a query string variable
-    static const uint32_t        QUERY_NAME_MAX;
+    static const std::uint32_t        QUERY_NAME_MAX;
 
     /// maximum length for the value of a query string variable
-    static const uint32_t        QUERY_VALUE_MAX;
+    static const std::uint32_t        QUERY_VALUE_MAX;
 
     /// maximum length for the name of a cookie name
-    static const uint32_t        COOKIE_NAME_MAX;
+    static const std::uint32_t        COOKIE_NAME_MAX;
 
     /// maximum length for the value of a cookie; also used for path and domain
-    static const uint32_t        COOKIE_VALUE_MAX;
+    static const std::uint32_t        COOKIE_VALUE_MAX;
 
 
     /// primary logging interface used by this class
@@ -624,7 +624,7 @@ private:
     payload_handler_t                   m_payload_handler;
 
     /// Used for parsing the HTTP response status code
-    uint16_t                     m_status_code;
+    std::uint16_t                     m_status_code;
 
     /// Used for parsing the HTTP response status message
     std::string                         m_status_message;

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -46,7 +46,7 @@ public:
     static const std::size_t        DEFAULT_CONTENT_MAX;
 
     /// callback type used to consume payload content
-    typedef boost::function2<void, const char *, std::size_t>   payload_handler_t;
+    typedef std::function<void(const char *, std::size_t)>   payload_handler_t;
     
     /// class-specific error code values
     enum error_value_t {
@@ -72,7 +72,7 @@ public:
     
     /// class-specific error category
     class error_category_t
-        : public boost::system::error_category
+        : public asio::error_category
     {
     public:
         const char *name() const BOOST_SYSTEM_NOEXCEPT { return "parser"; }
@@ -152,7 +152,7 @@ public:
      *                        true = finished parsing HTTP message,
      *                        indeterminate = not yet finished parsing HTTP message
      */
-    boost::tribool parse(http::message& http_msg, boost::system::error_code& ec);
+    boost::tribool parse(http::message& http_msg, asio::error_code& ec);
 
     /**
      * attempts to continue parsing despite having missed data (length is known but content is not)
@@ -167,7 +167,7 @@ public:
      *                        indeterminate = not yet finished parsing HTTP message
      */
     boost::tribool parse_missing_data(http::message& http_msg, std::size_t len,
-        boost::system::error_code& ec);
+        asio::error_code& ec);
 
     /**
      * finishes parsing an HTTP response message
@@ -228,7 +228,7 @@ public:
      * @param http_msg the HTTP message object being parsed
      */
     inline void skip_header_parsing(http::message& http_msg) {
-        boost::system::error_code ec;
+        asio::error_code ec;
         finish_header_parsing(http_msg, ec);
     }
     
@@ -418,7 +418,7 @@ public:
      *                        indeterminate = payload content is available to be parsed
      */
     boost::tribool finish_header_parsing(http::message& http_msg,
-                                         boost::system::error_code& ec);
+                                         asio::error_code& ec);
 
     /**
      * parses an X-Forwarded-For HTTP header, and extracts from it an IP
@@ -441,7 +441,7 @@ public:
 protected:
 
     /// Called after we have finished parsing the HTTP message headers
-    virtual void finished_parsing_headers(const boost::system::error_code& /* ec */) {}
+    virtual void finished_parsing_headers(const asio::error_code& /* ec */) {}
     
     /**
      * parses an HTTP message up to the end of the headers using bytes 
@@ -455,7 +455,7 @@ protected:
      *                        true = finished parsing HTTP headers,
      *                        indeterminate = not yet finished parsing HTTP headers
      */
-    boost::tribool parse_headers(http::message& http_msg, boost::system::error_code& ec);
+    boost::tribool parse_headers(http::message& http_msg, asio::error_code& ec);
 
     /**
      * updates an http::message object with data obtained from parsing headers
@@ -476,7 +476,7 @@ protected:
      *                        indeterminate = message is not yet finished
      */
     boost::tribool parse_chunks(http::message::chunk_cache_t& chunk_buffers,
-        boost::system::error_code& ec);
+        asio::error_code& ec);
 
     /**
      * consumes payload content in the parser's read buffer 
@@ -490,7 +490,7 @@ protected:
      *                        indeterminate = message is not yet finished
      */
     boost::tribool consume_content(http::message& http_msg,
-        boost::system::error_code& ec);
+        asio::error_code& ec);
 
     /**
      * consume the bytes available in the read buffer, converting them into
@@ -514,8 +514,8 @@ protected:
      * @param ec error code variable to define
      * @param ev error value to raise
      */
-    static inline void set_error(boost::system::error_code& ec, error_value_t ev) {
-        ec = boost::system::error_code(static_cast<int>(ev), get_error_category());
+    static inline void set_error(asio::error_code& ec, error_value_t ev) {
+        ec = asio::error_code(static_cast<int>(ev), get_error_category());
     }
 
     /// creates the unique parser error_category_t

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -11,10 +11,11 @@
 #define __PION_HTTP_PARSER_HEADER__
 
 #include <string>
+#include <thread>
+#include <mutex>
 #include <boost/noncopyable.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/thread/once.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/http/message.hpp>
@@ -432,7 +433,7 @@ public:
     
     /// returns an instance of parser::error_category_t
     static inline error_category_t& get_error_category(void) {
-        boost::call_once(parser::create_error_category, m_instance_flag);
+        std::call_once(m_instance_flag, parser::create_error_category);
         return *m_error_category_ptr;
     }
 
@@ -534,31 +535,31 @@ protected:
     static const boost::uint32_t        STATUS_MESSAGE_MAX;
 
     /// maximum length for the request method
-    static const boost::uint32_t        METHOD_MAX;
+    static const uint32_t        METHOD_MAX;
 
     /// maximum length for the resource requested
-    static const boost::uint32_t        RESOURCE_MAX;
+    static const uint32_t        RESOURCE_MAX;
 
     /// maximum length for the query string
-    static const boost::uint32_t        QUERY_STRING_MAX;
+    static const uint32_t        QUERY_STRING_MAX;
 
     /// maximum length for an HTTP header name
-    static const boost::uint32_t        HEADER_NAME_MAX;
+    static const uint32_t        HEADER_NAME_MAX;
 
     /// maximum length for an HTTP header value
-    static const boost::uint32_t        HEADER_VALUE_MAX;
+    static const uint32_t        HEADER_VALUE_MAX;
 
     /// maximum length for the name of a query string variable
-    static const boost::uint32_t        QUERY_NAME_MAX;
+    static const uint32_t        QUERY_NAME_MAX;
 
     /// maximum length for the value of a query string variable
-    static const boost::uint32_t        QUERY_VALUE_MAX;
+    static const uint32_t        QUERY_VALUE_MAX;
 
     /// maximum length for the name of a cookie name
-    static const boost::uint32_t        COOKIE_NAME_MAX;
+    static const uint32_t        COOKIE_NAME_MAX;
 
     /// maximum length for the value of a cookie; also used for path and domain
-    static const boost::uint32_t        COOKIE_VALUE_MAX;
+    static const uint32_t        COOKIE_VALUE_MAX;
 
 
     /// primary logging interface used by this class
@@ -623,7 +624,7 @@ private:
     payload_handler_t                   m_payload_handler;
 
     /// Used for parsing the HTTP response status code
-    boost::uint16_t                     m_status_code;
+    uint16_t                     m_status_code;
 
     /// Used for parsing the HTTP response status message
     std::string                         m_status_message;
@@ -680,7 +681,7 @@ private:
     static error_category_t *           m_error_category_ptr;
         
     /// used to ensure thread safety of the parser error_category_t
-    static boost::once_flag             m_instance_flag;
+    static std::once_flag             m_instance_flag;
 };
 
 

--- a/include/pion/http/plugin_server.hpp
+++ b/include/pion/http/plugin_server.hpp
@@ -11,9 +11,9 @@
 #define __PION_PLUGIN_SERVER_HEADER__
 
 #include <string>
-#include <boost/asio.hpp>
+#include <memory>
+#include <asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/plugin.hpp>
 #include <pion/plugin_manager.hpp>
@@ -53,7 +53,7 @@ public:
      * 
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    explicit plugin_server(const boost::asio::ip::tcp::endpoint& endpoint)
+    explicit plugin_server(const asio::ip::tcp::endpoint& endpoint)
         : http::server(endpoint)
     { 
         set_logger(PION_GET_LOGGER("pion.http.plugin_server"));
@@ -77,7 +77,7 @@ public:
      * @param sched the scheduler that will be used to manage worker threads
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    plugin_server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
+    plugin_server(scheduler& sched, const asio::ip::tcp::endpoint& endpoint)
         : http::server(sched, endpoint)
     { 
         set_logger(PION_GET_LOGGER("pion.http.plugin_server"));
@@ -137,13 +137,13 @@ protected:
     /// called before the TCP server starts listening for new connections
     virtual void before_starting(void) {
         // call the start() method for each web service associated with this server
-        m_services.run(boost::bind(&http::plugin_service::start, _1));
+        m_services.run(std::bind(&http::plugin_service::start, std::placeholders::_1));
     }
     
     /// called after the TCP server has stopped listening for new connections
     virtual void after_stopping(void) {
         // call the stop() method for each web service associated with this server
-        m_services.run(boost::bind(&http::plugin_service::stop, _1));
+        m_services.run(std::bind(&http::plugin_service::stop, std::placeholders::_1));
     }
 
     
@@ -159,7 +159,7 @@ private:
 
 
 /// data type for a web server pointer
-typedef boost::shared_ptr<plugin_server>        plugin_server_ptr;
+typedef std::shared_ptr<plugin_server>        plugin_server_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/plugin_server.hpp
+++ b/include/pion/http/plugin_server.hpp
@@ -13,7 +13,6 @@
 #include <string>
 #include <memory>
 #include <asio.hpp>
-#include <boost/bind.hpp>
 #include <pion/config.hpp>
 #include <pion/plugin.hpp>
 #include <pion/plugin_manager.hpp>

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -40,7 +40,7 @@ public:
     inline tcp::connection_ptr& get_connection(void) { return m_tcp_conn; }
     
     /// sets the maximum number of seconds for read operations
-    inline void set_timeout(uint32_t seconds) { m_read_timeout = seconds; }
+    inline void set_timeout(std::uint32_t seconds) { m_read_timeout = seconds; }
 
     
 protected:
@@ -92,7 +92,7 @@ private:
 
 
     /// default maximum number of seconds for read operations
-    static const uint32_t            DEFAULT_READ_TIMEOUT;
+    static const std::uint32_t            DEFAULT_READ_TIMEOUT;
 
 
     /// The HTTP connection that has a new HTTP message to parse
@@ -102,7 +102,7 @@ private:
     tcp::timer_ptr                             m_timer_ptr;
 
     /// maximum number of seconds for read operations
-    uint32_t                         m_read_timeout;
+    std::uint32_t                         m_read_timeout;
 };
 
 

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -40,7 +40,7 @@ public:
     inline tcp::connection_ptr& get_connection(void) { return m_tcp_conn; }
     
     /// sets the maximum number of seconds for read operations
-    inline void set_timeout(boost::uint32_t seconds) { m_read_timeout = seconds; }
+    inline void set_timeout(uint32_t seconds) { m_read_timeout = seconds; }
 
     
 protected:

--- a/include/pion/http/reader.hpp
+++ b/include/pion/http/reader.hpp
@@ -10,7 +10,7 @@
 #ifndef __PION_HTTP_READER_HEADER__
 #define __PION_HTTP_READER_HEADER__
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <pion/config.hpp>
 #include <pion/http/parser.hpp>
 #include <pion/http/message.hpp>
@@ -63,8 +63,7 @@ protected:
      * @param read_error error status from the last read operation
      * @param bytes_read number of bytes consumed by the last read operation
      */
-    void consume_bytes(const boost::system::error_code& read_error,
-                      std::size_t bytes_read);
+    void consume_bytes(const asio::error_code& read_error, std::size_t bytes_read);
 
     /// Consumes bytes that have been read using an HTTP parser
     void consume_bytes(void);
@@ -73,7 +72,7 @@ protected:
     virtual void read_bytes(void) = 0;
 
     /// Called after we have finished reading/parsing the HTTP message
-    virtual void finished_reading(const boost::system::error_code& ec) = 0;
+    virtual void finished_reading(const asio::error_code& ec) = 0;
 
     /// Returns a reference to the HTTP message being parsed
     virtual http::message& get_message(void) = 0;
@@ -89,11 +88,11 @@ private:
      *
      * @param read_error error status from the last read operation
      */
-    void handle_read_error(const boost::system::error_code& read_error);
+    void handle_read_error(const asio::error_code& read_error);
 
 
     /// default maximum number of seconds for read operations
-    static const boost::uint32_t            DEFAULT_READ_TIMEOUT;
+    static const uint32_t            DEFAULT_READ_TIMEOUT;
 
 
     /// The HTTP connection that has a new HTTP message to parse
@@ -103,7 +102,7 @@ private:
     tcp::timer_ptr                             m_timer_ptr;
 
     /// maximum number of seconds for read operations
-    boost::uint32_t                         m_read_timeout;
+    uint32_t                         m_read_timeout;
 };
 
 

--- a/include/pion/http/request.hpp
+++ b/include/pion/http/request.hpp
@@ -10,7 +10,7 @@
 #ifndef __PION_HTTP_REQUEST_HEADER__
 #define __PION_HTTP_REQUEST_HEADER__
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <pion/config.hpp>
 #include <pion/http/message.hpp>
 #include <pion/user.hpp>
@@ -214,7 +214,7 @@ private:
 
 
 /// data type for a HTTP request pointer
-typedef boost::shared_ptr<request>      request_ptr;
+typedef std::shared_ptr<request>      request_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/request_reader.hpp
+++ b/include/pion/http/request_reader.hpp
@@ -10,12 +10,9 @@
 #ifndef __PION_HTTP_REQUEST_READER_HEADER__
 #define __PION_HTTP_REQUEST_READER_HEADER__
 
-#include <boost/asio.hpp>
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function2.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
+#include <memory>
+#include <functional>
+#include <asio.hpp>
 #include <pion/config.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/reader.hpp>
@@ -30,14 +27,14 @@ namespace http {    // begin namespace http
 ///
 class request_reader :
     public http::reader,
-    public boost::enable_shared_from_this<request_reader>
+    public std::enable_shared_from_this<request_reader>
 {
 
 public:
 
     /// function called after the HTTP message has been parsed
-    typedef boost::function3<void, http::request_ptr, tcp::connection_ptr,
-        const boost::system::error_code&>   finished_handler_t;
+    typedef std::function<void(http::request_ptr, tcp::connection_ptr,
+        const asio::error_code&)>   finished_handler_t;
 
     
     // default destructor
@@ -49,10 +46,10 @@ public:
      * @param tcp_conn TCP connection containing a new message to parse
      * @param handler function called after the message has been parsed
      */
-    static inline boost::shared_ptr<request_reader>
+    static inline std::shared_ptr<request_reader>
         create(const tcp::connection_ptr& tcp_conn, finished_handler_t handler)
     {
-        return boost::shared_ptr<request_reader>
+        return std::shared_ptr<request_reader>
             (new request_reader(tcp_conn, handler));
     }
     
@@ -78,20 +75,20 @@ protected:
         
     /// Reads more bytes from the TCP connection
     virtual void read_bytes(void) {
-        get_connection()->async_read_some(boost::bind(&request_reader::consume_bytes,
+        get_connection()->async_read_some(std::bind(static_cast<void(request_reader::*)(const asio::error_code&, std::size_t)>(&request_reader::consume_bytes),
                                                         shared_from_this(),
-                                                        boost::asio::placeholders::error,
-                                                        boost::asio::placeholders::bytes_transferred));
+                                                        std::placeholders::_1,
+                                                        std::placeholders::_2));
     }
 
     /// Called after we have finished parsing the HTTP message headers
-    virtual void finished_parsing_headers(const boost::system::error_code& ec) {
+    virtual void finished_parsing_headers(const asio::error_code& ec) {
         // call the finished headers handler with the HTTP message
         if (m_parsed_headers) m_parsed_headers(m_http_msg, get_connection(), ec);
     }
     
     /// Called after we have finished reading/parsing the HTTP message
-    virtual void finished_reading(const boost::system::error_code& ec) {
+    virtual void finished_reading(const asio::error_code& ec) {
         // call the finished handler with the finished HTTP message
         if (m_finished) m_finished(m_http_msg, get_connection(), ec);
     }
@@ -111,7 +108,7 @@ protected:
 
 
 /// data type for a request_reader pointer
-typedef boost::shared_ptr<request_reader>    request_reader_ptr;
+typedef std::shared_ptr<request_reader>    request_reader_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -12,7 +12,6 @@
 
 #include <memory>
 #include <asio.hpp>
-#include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>

--- a/include/pion/http/request_writer.hpp
+++ b/include/pion/http/request_writer.hpp
@@ -10,11 +10,10 @@
 #ifndef __PION_HTTP_REQUEST_WRITER_HEADER__
 #define __PION_HTTP_REQUEST_WRITER_HEADER__
 
-#include <boost/asio.hpp>
+#include <memory>
+#include <asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
@@ -29,7 +28,7 @@ namespace http {    // begin namespace http
 /// 
 class request_writer :
     public http::writer,
-    public boost::enable_shared_from_this<request_writer>
+    public std::enable_shared_from_this<request_writer>
 {
 public:
     
@@ -42,13 +41,13 @@ public:
      * @param tcp_conn TCP connection used to send the request
      * @param handler function called after the request has been sent
      * 
-     * @return boost::shared_ptr<request_writer> shared pointer to
+     * @return std::shared_ptr<request_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline std::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
                                                               finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<request_writer>(new request_writer(tcp_conn, handler));
+        return std::shared_ptr<request_writer>(new request_writer(tcp_conn, handler));
     }
     
     /**
@@ -58,14 +57,14 @@ public:
      * @param http_request_ptr pointer to the request that will be sent
      * @param handler function called after the request has been sent
      * 
-     * @return boost::shared_ptr<request_writer> shared pointer to
+     * @return std::shared_ptr<request_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline std::shared_ptr<request_writer> create(const tcp::connection_ptr& tcp_conn,
                                                               const http::request_ptr& http_request_ptr,
                                                               finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<request_writer>(new request_writer(tcp_conn, http_request_ptr, handler));
+        return std::shared_ptr<request_writer>(new request_writer(tcp_conn, http_request_ptr, handler));
     }
 
     /// returns a non-const reference to the request that will be sent
@@ -125,9 +124,9 @@ protected:
 
     /// returns a function bound to http::writer::handle_write()
     virtual write_handler_t bind_to_write_handler(void) {
-        return boost::bind(&request_writer::handle_write, shared_from_this(),
-                           boost::asio::placeholders::error,
-                           boost::asio::placeholders::bytes_transferred);
+        return std::bind(&request_writer::handle_write, shared_from_this(),
+                           std::placeholders::_1,
+                           std::placeholders::_2);
     }
 
     /**
@@ -136,7 +135,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    virtual void handle_write(const boost::system::error_code& write_error,
+    virtual void handle_write(const asio::error_code& write_error,
                              std::size_t bytes_written)
     {
         (void)bytes_written;
@@ -166,7 +165,7 @@ private:
 
 
 /// data type for a request_writer pointer
-typedef boost::shared_ptr<request_writer>    request_writer_ptr;
+typedef std::shared_ptr<request_writer>    request_writer_ptr;
 
 
 /// override operator<< for convenience

--- a/include/pion/http/response.hpp
+++ b/include/pion/http/response.hpp
@@ -11,7 +11,6 @@
 #define __PION_HTTP_RESPONSE_HEADER__
 
 #include <boost/shared_ptr.hpp>
-#include <boost/lexical_cast.hpp>
 #include <pion/config.hpp>
 #include <pion/http/message.hpp>
 #include <pion/http/request.hpp>
@@ -206,7 +205,7 @@ protected:
         m_first_line = get_version_string();
         m_first_line += ' ';
         // append the response status code
-        m_first_line +=  boost::lexical_cast<std::string>(m_status_code);
+        m_first_line += std::to_string(m_status_code);
         m_first_line += ' ';
         // append the response status message
         m_first_line += m_status_message;
@@ -234,7 +233,7 @@ private:
 
 
 /// data type for a HTTP response pointer
-typedef boost::shared_ptr<response>     response_ptr;
+typedef std::shared_ptr<response>     response_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/response.hpp
+++ b/include/pion/http/response.hpp
@@ -10,7 +10,6 @@
 #ifndef __PION_HTTP_RESPONSE_HEADER__
 #define __PION_HTTP_RESPONSE_HEADER__
 
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/http/message.hpp>
 #include <pion/http/request.hpp>

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -10,11 +10,10 @@
 #ifndef __PION_HTTP_RESPONSE_WRITER_HEADER__
 #define __PION_HTTP_RESPONSE_WRITER_HEADER__
 
-#include <boost/asio.hpp>
+#include <memory>
+#include <asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/request.hpp>
@@ -30,7 +29,7 @@ namespace http {    // begin namespace http
 /// 
 class PION_API response_writer :
     public http::writer,
-    public boost::enable_shared_from_this<response_writer>
+    public std::enable_shared_from_this<response_writer>
 {
 public:
     
@@ -44,14 +43,14 @@ public:
      * @param http_response pointer to the response that will be sent
      * @param handler function called after the response has been sent
      * 
-     * @return boost::shared_ptr<response_writer> shared pointer to
+     * @return std::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline std::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
                                                             const http::response_ptr& http_response_ptr,
                                                             finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_response_ptr, handler));
+        return std::shared_ptr<response_writer>(new response_writer(tcp_conn, http_response_ptr, handler));
     }
 
     /**
@@ -61,14 +60,14 @@ public:
      * @param http_request the request we are responding to
      * @param handler function called after the request has been sent
      * 
-     * @return boost::shared_ptr<response_writer> shared pointer to
+     * @return std::shared_ptr<response_writer> shared pointer to
      *         the new writer object that was created
      */
-    static inline boost::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
+    static inline std::shared_ptr<response_writer> create(const tcp::connection_ptr& tcp_conn,
                                                             const http::request& http_request,
                                                             finished_handler_t handler = finished_handler_t())
     {
-        return boost::shared_ptr<response_writer>(new response_writer(tcp_conn, http_request, handler));
+        return std::shared_ptr<response_writer>(new response_writer(tcp_conn, http_request, handler));
     }
     
     /// returns a non-const reference to the response that will be sent
@@ -133,9 +132,9 @@ protected:
 
     /// returns a function bound to http::writer::handle_write()
     virtual write_handler_t bind_to_write_handler(void) {
-        return boost::bind(&response_writer::handle_write, shared_from_this(),
-                           boost::asio::placeholders::error,
-                           boost::asio::placeholders::bytes_transferred);
+        return std::bind(&response_writer::handle_write, shared_from_this(),
+                           std::placeholders::_1,
+                           std::placeholders::_2);
     }
 
     /**
@@ -144,7 +143,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    virtual void handle_write(const boost::system::error_code& write_error,
+    virtual void handle_write(const asio::error_code& write_error,
                              std::size_t bytes_written)
     {
         (void)bytes_written;
@@ -174,7 +173,7 @@ private:
 
 
 /// data type for a response_writer pointer
-typedef boost::shared_ptr<response_writer>   response_writer_ptr;
+typedef std::shared_ptr<response_writer>   response_writer_ptr;
 
 
 /// override operator<< for convenience

--- a/include/pion/http/response_writer.hpp
+++ b/include/pion/http/response_writer.hpp
@@ -12,7 +12,6 @@
 
 #include <memory>
 #include <asio.hpp>
-#include <boost/bind.hpp>
 #include <boost/noncopyable.hpp>
 #include <pion/config.hpp>
 #include <pion/http/writer.hpp>

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -143,7 +143,7 @@ public:
     /// clears the collection of resources recognized by the HTTP server
     virtual void clear(void) {
         if (is_listening()) stop();
-        boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+        std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
         m_resources.clear();
     }
 
@@ -276,7 +276,7 @@ private:
     error_handler_t             m_server_error_handler;
 
     /// mutex used to protect access to the resources
-    mutable boost::mutex        m_resource_mutex;
+    mutable std::mutex        m_resource_mutex;
 
     /// pointer to authentication handler object
     http::auth_ptr              m_auth_ptr;

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -14,7 +14,6 @@
 #include <string>
 #include <functional>
 #include <asio.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/server.hpp>
 #include <pion/tcp/connection.hpp>

--- a/include/pion/http/server.hpp
+++ b/include/pion/http/server.hpp
@@ -12,11 +12,8 @@
 
 #include <map>
 #include <string>
-#include <boost/asio.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function2.hpp>
-#include <boost/function/function3.hpp>
-#include <boost/shared_ptr.hpp>
+#include <functional>
+#include <asio.hpp>
 #include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/server.hpp>
@@ -40,11 +37,10 @@ class PION_API server :
 public:
 
     /// type of function that is used to handle requests
-    typedef boost::function2<void, const http::request_ptr&, const tcp::connection_ptr&>  request_handler_t;
+    typedef std::function<void(const http::request_ptr&, const tcp::connection_ptr&)>  request_handler_t;
 
     /// handler for requests that result in "500 Server Error"
-    typedef boost::function3<void, const http::request_ptr&, const tcp::connection_ptr&,
-        const std::string&> error_handler_t;
+    typedef std::function<void(const http::request_ptr&, const tcp::connection_ptr&, const std::string&)> error_handler_t;
 
 
     /// default destructor
@@ -70,7 +66,7 @@ public:
      * 
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    explicit server(const boost::asio::ip::tcp::endpoint& endpoint)
+    explicit server(const asio::ip::tcp::endpoint& endpoint)
         : tcp::server(endpoint),
         m_bad_request_handler(server::handle_bad_request),
         m_not_found_handler(server::handle_not_found_request),
@@ -102,7 +98,7 @@ public:
      * @param sched the scheduler that will be used to manage worker threads
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
+    server(scheduler& sched, const asio::ip::tcp::endpoint& endpoint)
         : tcp::server(sched, endpoint),
         m_bad_request_handler(server::handle_bad_request),
         m_not_found_handler(server::handle_not_found_request),
@@ -240,7 +236,7 @@ protected:
      * @param ec error_code contains additional information for parsing errors
      */
     virtual void handle_request(const http::request_ptr& http_request_ptr,
-                                const tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec);
+                                const tcp::connection_ptr& tcp_conn, const asio::error_code& ec);
 
     /**
      * searches for the appropriate request handler to use for a given resource
@@ -291,7 +287,7 @@ private:
 
 
 /// data type for a HTTP server pointer
-typedef boost::shared_ptr<server>	server_ptr;
+typedef std::shared_ptr<server>	server_ptr;
 
 
 }   // end namespace http

--- a/include/pion/http/writer.hpp
+++ b/include/pion/http/writer.hpp
@@ -12,11 +12,8 @@
 
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function0.hpp>
-#include <boost/function/function2.hpp>
-#include <boost/asio.hpp>
+#include <functional>
+#include <asio.hpp>
 #include <boost/noncopyable.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
@@ -37,10 +34,10 @@ class PION_API writer :
 protected:
     
     /// function called after the HTTP message has been sent
-    typedef boost::function1<void,const boost::system::error_code&> finished_handler_t;
+    typedef std::function<void(const asio::error_code&)> finished_handler_t;
 
     /// data type for a function that handles write operations
-    typedef boost::function2<void,const boost::system::error_code&,std::size_t> write_handler_t;
+    typedef std::function<void(const asio::error_code&,std::size_t)> write_handler_t;
     
     
     /**
@@ -62,7 +59,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    virtual void handle_write(const boost::system::error_code& write_error,
+    virtual void handle_write(const asio::error_code& write_error,
                               std::size_t bytes_written) = 0;
 
     
@@ -77,7 +74,7 @@ protected:
     virtual write_handler_t bind_to_write_handler(void) = 0;
     
     /// called after we have finished sending the HTTP message
-    inline void finished_writing(const boost::system::error_code& ec) {
+    inline void finished_writing(const asio::error_code& ec) {
         if (m_finished) m_finished(ec);
     }
     
@@ -137,7 +134,7 @@ public:
     inline void write_no_copy(const std::string& data) {
         if (! data.empty()) {
             flush_content_stream();
-            m_content_buffers.push_back(boost::asio::buffer(data));
+            m_content_buffers.push_back(asio::buffer(data));
             m_content_length += data.size();
         }
     }
@@ -152,7 +149,7 @@ public:
     inline void write_no_copy(void *data, size_t length) {
         if (length > 0) {
             flush_content_stream();
-            m_content_buffers.push_back(boost::asio::buffer(data, length));
+            m_content_buffers.push_back(asio::buffer(data, length));
             m_content_length += length;
         }
     }
@@ -276,7 +273,7 @@ private:
             // send data in the write buffers
             m_tcp_conn->async_write(write_buffers, send_handler);
         } else {
-            finished_writing(boost::asio::error::connection_reset);
+            finished_writing(asio::error::connection_reset);
         }
     }
     
@@ -297,7 +294,7 @@ private:
                 m_content_stream.str("");
                 m_content_length += string_to_add.size();
                 m_text_cache.push_back(string_to_add);
-                m_content_buffers.push_back(boost::asio::buffer(m_text_cache.back()));
+                m_content_buffers.push_back(asio::buffer(m_text_cache.back()));
             }
             m_stream_is_empty = true;
         }
@@ -312,11 +309,11 @@ private:
                 delete[] i->first;
             }
         }
-        inline boost::asio::const_buffer add(const void *ptr, const size_t size) {
+        inline asio::const_buffer add(const void *ptr, const size_t size) {
             char *data_ptr = new char[size];
             memcpy(data_ptr, ptr, size);
             push_back( std::make_pair(data_ptr, size) );
-            return boost::asio::buffer(data_ptr, size);
+            return asio::buffer(data_ptr, size);
         }
     };
     
@@ -363,7 +360,7 @@ private:
 
 
 /// data type for a writer pointer
-typedef boost::shared_ptr<writer>   writer_ptr;
+typedef std::shared_ptr<writer>   writer_ptr;
 
 
 /// override operator<< for convenience

--- a/include/pion/logger.hpp
+++ b/include/pion/logger.hpp
@@ -123,7 +123,7 @@
             virtual void close() {}
         protected:
             virtual void append(const log4cplus::spi::InternalLoggingEvent& event) {
-                boost::mutex::scoped_lock log_lock(m_log_mutex);
+                std::unique_lock<std::mutex> log_lock(m_log_mutex);
                 m_log_events.push_back(*event.clone());
             }
 
@@ -132,7 +132,7 @@
             LogEventBuffer  m_log_events;
 
             /// mutex to make class thread-safe
-            boost::mutex    m_log_mutex;
+            std::mutex    m_log_mutex;
         };
     }
 

--- a/include/pion/logger.hpp
+++ b/include/pion/logger.hpp
@@ -78,7 +78,7 @@
     #include <log4cplus/loggingmacros.h>
 
     #include <boost/circular_buffer.hpp>
-    #include <boost/thread/mutex.hpp>
+    #include <mutex>
 
     #if defined(_MSC_VER) && !defined(PION_CMAKE_BUILD)
         #if defined _DEBUG

--- a/include/pion/plugin.hpp
+++ b/include/pion/plugin.hpp
@@ -14,9 +14,9 @@
 #include <string>
 #include <map>
 #include <list>
+#include <mutex>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/once.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/filesystem/path.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
@@ -210,7 +210,7 @@ private:
         map_type                    m_plugin_map;
         
         /// mutex to make class thread-safe
-        boost::mutex                m_plugin_mutex;
+        std::mutex                m_plugin_mutex;
     };
 
     

--- a/include/pion/plugin.hpp
+++ b/include/pion/plugin.hpp
@@ -15,8 +15,8 @@
 #include <map>
 #include <list>
 #include <mutex>
+#include <thread>
 #include <boost/noncopyable.hpp>
-#include <boost/thread/once.hpp>
 #include <boost/filesystem/path.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
@@ -216,7 +216,7 @@ private:
     
     /// returns a singleton instance of config_type
     static inline config_type& get_plugin_config(void) {
-        boost::call_once(plugin::create_plugin_config, m_instance_flag);
+        std::call_once(m_instance_flag, plugin::create_plugin_config);
         return *m_config_ptr;
     }
     
@@ -283,7 +283,7 @@ private:
     static const std::string            PION_CONFIG_EXTENSION;
     
     /// used to ensure thread safety of the plugin_config singleton
-    static boost::once_flag             m_instance_flag;
+    static std::once_flag             m_instance_flag;
 
     /// pointer to the plugin_config singleton
     static config_type *           m_config_ptr;

--- a/include/pion/plugin_manager.hpp
+++ b/include/pion/plugin_manager.hpp
@@ -12,7 +12,7 @@
 
 #include <map>
 #include <string>
-#include <boost/cstdint.hpp>
+
 #include <boost/assert.hpp>
 #include <boost/function.hpp>
 #include <boost/function/function1.hpp>
@@ -47,13 +47,13 @@ public:
 
     /// clears all the plug-in objects being managed
     inline void clear(void) {
-        boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+        std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
         m_plugin_map.clear();
     }
     
     /// returns true if there are no plug-in objects being managed
     inline bool empty(void) const { 
-        boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+        std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
         return m_plugin_map.empty();
     }
     
@@ -178,7 +178,7 @@ protected:
     map_type                m_plugin_map;
 
     /// mutex to make class thread-safe
-    mutable boost::mutex    m_plugin_mutex;
+    mutable std::mutex    m_plugin_mutex;
 };
 
     
@@ -189,7 +189,7 @@ inline void plugin_manager<PluginType>::add(const std::string& plugin_id,
                                             PluginType *plugin_object_ptr)
 {
     plugin_ptr<PluginType> plugin_ptr;
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     m_plugin_map.insert(std::make_pair(plugin_id,
                                        std::make_pair(plugin_object_ptr, plugin_ptr)));
 }
@@ -197,7 +197,7 @@ inline void plugin_manager<PluginType>::add(const std::string& plugin_id,
 template <typename PluginType>
 inline void plugin_manager<PluginType>::remove(const std::string& plugin_id)
 {
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     typename pion::plugin_manager<PluginType>::map_type::iterator i = m_plugin_map.find(plugin_id);
     if (i == m_plugin_map.end())
         BOOST_THROW_EXCEPTION( error::plugin_not_found() << error::errinfo_plugin_name(plugin_id) );
@@ -213,7 +213,7 @@ template <typename PluginType>
 inline void plugin_manager<PluginType>::replace(const std::string& plugin_id, PluginType *plugin_ptr)
 {
     BOOST_ASSERT(plugin_ptr);
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     typename pion::plugin_manager<PluginType>::map_type::iterator i = m_plugin_map.find(plugin_id);
     if (i == m_plugin_map.end())
         BOOST_THROW_EXCEPTION( error::plugin_not_found() << error::errinfo_plugin_name(plugin_id) );
@@ -228,7 +228,7 @@ inline void plugin_manager<PluginType>::replace(const std::string& plugin_id, Pl
 template <typename PluginType>
 inline PluginType *plugin_manager<PluginType>::clone(const std::string& plugin_id)
 {
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     typename pion::plugin_manager<PluginType>::map_type::iterator i = m_plugin_map.find(plugin_id);
     if (i == m_plugin_map.end())
         BOOST_THROW_EXCEPTION( error::plugin_not_found() << error::errinfo_plugin_name(plugin_id) );
@@ -251,7 +251,7 @@ inline PluginType *plugin_manager<PluginType>::load(const std::string& plugin_id
     PluginType *plugin_object_ptr(plugin_ptr.create());
     
     // add the new plug-in object to our map
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     m_plugin_map.insert(std::make_pair(plugin_id,
                                        std::make_pair(plugin_object_ptr, plugin_ptr)));
 
@@ -262,7 +262,7 @@ template <typename PluginType>
 inline PluginType *plugin_manager<PluginType>::get(const std::string& plugin_id)
 {
     PluginType *plugin_object_ptr = NULL;
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     typename pion::plugin_manager<PluginType>::map_type::iterator i = m_plugin_map.find(plugin_id);
     if (i != m_plugin_map.end())
         plugin_object_ptr = i->second.first;
@@ -273,7 +273,7 @@ template <typename PluginType>
 inline const PluginType *plugin_manager<PluginType>::get(const std::string& plugin_id) const
 {
     const PluginType *plugin_object_ptr = NULL;
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     typename pion::plugin_manager<PluginType>::map_type::const_iterator i = m_plugin_map.find(plugin_id);
     if (i != m_plugin_map.end())
         plugin_object_ptr = i->second.first;
@@ -284,7 +284,7 @@ template <typename PluginType>
 inline plugin_ptr<PluginType> plugin_manager<PluginType>::get_lib_ptr(const std::string& plugin_id) const
 {
     plugin_ptr<PluginType> plugin_ptr;
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     typename pion::plugin_manager<PluginType>::map_type::const_iterator i = m_plugin_map.find(plugin_id);
     if (i != m_plugin_map.end())
         plugin_ptr = i->second.second;
@@ -298,7 +298,7 @@ inline PluginType *plugin_manager<PluginType>::find(const std::string& resource)
     PluginType *plugin_object_ptr = NULL;
     
     // lock mutex for thread safety (this should probably use ref counters)
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     
     // check if no plug-ins are being managed
     if (m_plugin_map.empty()) return plugin_object_ptr;
@@ -336,7 +336,7 @@ inline PluginType *plugin_manager<PluginType>::find(const std::string& resource)
 template <typename PluginType>
 inline void plugin_manager<PluginType>::run(PluginRunFunction run_func)
 {
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     for (typename pion::plugin_manager<PluginType>::map_type::iterator i = m_plugin_map.begin();
          i != m_plugin_map.end(); ++i)
     {
@@ -359,7 +359,7 @@ template <typename PluginType>
 inline boost::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
 {
     boost::uint64_t stat_value = 0;
-    boost::mutex::scoped_lock plugins_lock(m_plugin_mutex);
+    std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     for (typename pion::plugin_manager<PluginType>::map_type::const_iterator i = m_plugin_map.begin();
          i != m_plugin_map.end(); ++i)
     {

--- a/include/pion/plugin_manager.hpp
+++ b/include/pion/plugin_manager.hpp
@@ -12,11 +12,9 @@
 
 #include <map>
 #include <string>
-
+#include <functional>
+#include <mutex>
 #include <boost/assert.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function1.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/plugin.hpp>
@@ -36,7 +34,7 @@ public:
     typedef std::function<void(PluginType*)>    PluginRunFunction;
 
     /// data type for a function that may be called by the getStat() method
-    typedef std::function<boost::uint64_t(const PluginType*)>   PluginStatFunction;
+    typedef std::function<uint64_t(const PluginType*)>   PluginStatFunction;
 
     
     /// default constructor
@@ -150,7 +148,7 @@ public:
      *
      * @param stat_func the statistic function to execute for each plug-in object
      */
-    inline boost::uint64_t get_statistic(PluginStatFunction stat_func) const;
+    inline uint64_t get_statistic(PluginStatFunction stat_func) const;
     
     /**
      * returns a statistic value for a particular plug-in
@@ -158,7 +156,7 @@ public:
      * @param plugin_id unique identifier associated with the plug-in
      * @param stat_func the statistic function to execute
      */
-    inline boost::uint64_t get_statistic(const std::string& plugin_id,
+    inline uint64_t get_statistic(const std::string& plugin_id,
                                         PluginStatFunction stat_func) const;
         
     
@@ -356,9 +354,9 @@ inline void plugin_manager<PluginType>::run(const std::string& plugin_id,
 }
 
 template <typename PluginType>
-inline boost::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
+inline uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
 {
-    boost::uint64_t stat_value = 0;
+    uint64_t stat_value = 0;
     std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     for (typename pion::plugin_manager<PluginType>::map_type::const_iterator i = m_plugin_map.begin();
          i != m_plugin_map.end(); ++i)
@@ -369,7 +367,7 @@ inline boost::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunct
 }
 
 template <typename PluginType>
-inline boost::uint64_t plugin_manager<PluginType>::get_statistic(const std::string& plugin_id,
+inline uint64_t plugin_manager<PluginType>::get_statistic(const std::string& plugin_id,
                                                                 PluginStatFunction stat_func) const
 {
     // no need to lock (handled by plugin_manager::get())

--- a/include/pion/plugin_manager.hpp
+++ b/include/pion/plugin_manager.hpp
@@ -33,10 +33,10 @@ class plugin_manager
 public:
 
     /// data type for a function that may be called by the run() method
-    typedef boost::function1<void, PluginType*>    PluginRunFunction;
+    typedef std::function<void(PluginType*)>    PluginRunFunction;
 
     /// data type for a function that may be called by the getStat() method
-    typedef boost::function1<boost::uint64_t, const PluginType*>   PluginStatFunction;
+    typedef std::function<boost::uint64_t(const PluginType*)>   PluginStatFunction;
 
     
     /// default constructor

--- a/include/pion/plugin_manager.hpp
+++ b/include/pion/plugin_manager.hpp
@@ -34,7 +34,7 @@ public:
     typedef std::function<void(PluginType*)>    PluginRunFunction;
 
     /// data type for a function that may be called by the getStat() method
-    typedef std::function<uint64_t(const PluginType*)>   PluginStatFunction;
+    typedef std::function<std::uint64_t(const PluginType*)>   PluginStatFunction;
 
     
     /// default constructor
@@ -148,7 +148,7 @@ public:
      *
      * @param stat_func the statistic function to execute for each plug-in object
      */
-    inline uint64_t get_statistic(PluginStatFunction stat_func) const;
+    inline std::uint64_t get_statistic(PluginStatFunction stat_func) const;
     
     /**
      * returns a statistic value for a particular plug-in
@@ -156,7 +156,7 @@ public:
      * @param plugin_id unique identifier associated with the plug-in
      * @param stat_func the statistic function to execute
      */
-    inline uint64_t get_statistic(const std::string& plugin_id,
+    inline std::uint64_t get_statistic(const std::string& plugin_id,
                                         PluginStatFunction stat_func) const;
         
     
@@ -354,9 +354,9 @@ inline void plugin_manager<PluginType>::run(const std::string& plugin_id,
 }
 
 template <typename PluginType>
-inline uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
+inline std::uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction stat_func) const
 {
-    uint64_t stat_value = 0;
+    std::uint64_t stat_value = 0;
     std::unique_lock<std::mutex> plugins_lock(m_plugin_mutex);
     for (typename pion::plugin_manager<PluginType>::map_type::const_iterator i = m_plugin_map.begin();
          i != m_plugin_map.end(); ++i)
@@ -367,7 +367,7 @@ inline uint64_t plugin_manager<PluginType>::get_statistic(PluginStatFunction sta
 }
 
 template <typename PluginType>
-inline uint64_t plugin_manager<PluginType>::get_statistic(const std::string& plugin_id,
+inline std::uint64_t plugin_manager<PluginType>::get_statistic(const std::string& plugin_id,
                                                                 PluginStatFunction stat_func) const
 {
     // no need to lock (handled by plugin_manager::get())

--- a/include/pion/process.hpp
+++ b/include/pion/process.hpp
@@ -11,10 +11,10 @@
 #define __PION_PROCESS_HEADER__
 
 #include <string>
+#include <mutex>
+#include <condition_variable>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/once.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
 
 // Dump file generation support on Windows
@@ -99,10 +99,10 @@ protected:
         bool                    shutdown_now;
         
         /// triggered when it is time to shutdown
-        boost::condition        shutdown_cond;
+        std::condition_variable        shutdown_cond;
 
         /// used to protect the shutdown condition
-        boost::mutex            shutdown_mutex;
+        std::mutex            shutdown_mutex;
 
 // Dump file generation support on Windows
 #ifdef PION_WIN32

--- a/include/pion/process.hpp
+++ b/include/pion/process.hpp
@@ -12,9 +12,9 @@
 
 #include <string>
 #include <mutex>
+#include <thread>
 #include <condition_variable>
 #include <boost/noncopyable.hpp>
-#include <boost/thread/once.hpp>
 #include <pion/config.hpp>
 
 // Dump file generation support on Windows
@@ -119,7 +119,7 @@ protected:
 
     /// returns a singleton instance of config_type
     static inline config_type& get_config(void) {
-        boost::call_once(process::create_config, m_instance_flag);
+        std::call_once(m_instance_flag, process::create_config);
         return *m_config_ptr;
     }
 
@@ -131,7 +131,7 @@ private:
 
     
     /// used to ensure thread safety of the config_type singleton
-    static boost::once_flag             m_instance_flag;
+    static std::once_flag             m_instance_flag;
 
     /// pointer to the config_type singleton
     static config_type *          m_config_ptr;

--- a/include/pion/scheduler.hpp
+++ b/include/pion/scheduler.hpp
@@ -14,16 +14,13 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <condition_variable>
 #include <asio.hpp>
 #include <boost/assert.hpp>
 
 #include <boost/noncopyable.hpp>
-#include <boost/thread/thread.hpp>
-#include <boost/thread/xtime.hpp>
-#include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
-#include <condition_variable>
 
 
 namespace pion {    // begin namespace pion
@@ -66,10 +63,10 @@ public:
     inline bool is_running(void) const { return m_is_running; }
     
     /// sets the number of threads to be used (these are shared by all servers)
-    inline void set_num_threads(const boost::uint32_t n) { m_num_threads = n; }
+    inline void set_num_threads(const uint32_t n) { m_num_threads = n; }
     
     /// returns the number of threads currently in use
-    inline boost::uint32_t get_num_threads(void) const { return m_num_threads; }
+    inline uint32_t get_num_threads(void) const { return m_num_threads; }
 
     /// sets the logger to be used
     inline void set_logger(logger log_ptr) { m_logger = log_ptr; }
@@ -216,13 +213,13 @@ protected:
             PION_LOG_DEBUG(m_logger, "Waiting for threads to shutdown");
             
             // wait until all threads in the pool have stopped
-            boost::thread current_thread;
+//            std::thread current_thread;
             for (ThreadPool::iterator i = m_thread_pool.begin();
                  i != m_thread_pool.end(); ++i)
             {
                 // make sure we do not call join() for the current thread,
                 // since this may yield "undefined behavior"
-                if (**i != current_thread) (*i)->join();
+                if ((*i)->get_id() != std::this_thread::get_id()) (*i)->join();
             }
         }
     }
@@ -232,7 +229,7 @@ protected:
 
     
     /// typedef for a pool of worker threads
-    typedef std::vector<std::shared_ptr<boost::thread> >  ThreadPool;
+    typedef std::vector<std::shared_ptr<std::thread> >  ThreadPool;
     
     
     /// pool of threads used to perform work

--- a/include/pion/scheduler.hpp
+++ b/include/pion/scheduler.hpp
@@ -155,16 +155,16 @@ protected:
     
     
     /// default number of worker threads in the thread pool
-    static const boost::uint32_t    DEFAULT_NUM_THREADS;
+    static const uint32_t    DEFAULT_NUM_THREADS;
 
     /// number of nanoseconds in one full second (10 ^ 9)
-    static const boost::uint32_t    NSEC_IN_SECOND;
+    static const uint32_t    NSEC_IN_SECOND;
 
     /// number of microseconds in one full second (10 ^ 6)
-    static const boost::uint32_t    MICROSEC_IN_SECOND;
+    static const uint32_t    MICROSEC_IN_SECOND;
     
     /// number of seconds a timer should wait for to keep the IO services running
-    static const boost::uint32_t    KEEP_RUNNING_TIMER_SECONDS;
+    static const uint32_t    KEEP_RUNNING_TIMER_SECONDS;
 
 
     /// mutex to make class thread-safe
@@ -180,10 +180,10 @@ protected:
     std::condition_variable                m_scheduler_has_stopped;
 
     /// total number of worker threads in the pool
-    boost::uint32_t                 m_num_threads;
+    uint32_t                 m_num_threads;
 
     /// the scheduler will not shutdown until there are no more active users
-    boost::uint32_t                 m_active_users;
+    uint32_t                 m_active_users;
 
     /// true if the thread scheduler is running
     bool                            m_is_running;
@@ -312,7 +312,7 @@ public:
      *
      * @param n integer number representing the service object
      */
-    virtual asio::io_service& get_io_service(boost::uint32_t n) {
+    virtual asio::io_service& get_io_service(uint32_t n) {
         BOOST_ASSERT(n < m_num_threads);
         BOOST_ASSERT(n < m_service_pool.size());
         return m_service_pool[n]->first;
@@ -350,7 +350,7 @@ protected:
     service_pool_type   m_service_pool;
 
     /// the next service to use for scheduling work
-    boost::uint32_t     m_next_service;
+    uint32_t     m_next_service;
 };
     
     

--- a/include/pion/scheduler.hpp
+++ b/include/pion/scheduler.hpp
@@ -63,10 +63,10 @@ public:
     inline bool is_running(void) const { return m_is_running; }
     
     /// sets the number of threads to be used (these are shared by all servers)
-    inline void set_num_threads(const uint32_t n) { m_num_threads = n; }
+    inline void set_num_threads(const std::uint32_t n) { m_num_threads = n; }
     
     /// returns the number of threads currently in use
-    inline uint32_t get_num_threads(void) const { return m_num_threads; }
+    inline std::uint32_t get_num_threads(void) const { return m_num_threads; }
 
     /// sets the logger to be used
     inline void set_logger(logger log_ptr) { m_logger = log_ptr; }
@@ -101,7 +101,7 @@ public:
      * @param sleep_sec number of entire seconds to sleep for
      * @param sleep_nsec number of nanoseconds to sleep for (10^-9 in 1 second)
      */
-    inline static void sleep(uint32_t sleep_sec, uint32_t sleep_nsec) {
+    inline static void sleep(std::uint32_t sleep_sec, std::uint32_t sleep_nsec) {
         std::chrono::system_clock::time_point wakeup_time(get_wakeup_time(sleep_sec, sleep_nsec));
         std::this_thread::sleep_until(wakeup_time);
     }
@@ -117,7 +117,7 @@ public:
      */
     template <typename ConditionType, typename LockType>
     inline static void sleep(ConditionType& wakeup_condition, LockType& wakeup_lock,
-                             uint32_t sleep_sec, uint32_t sleep_nsec)
+                             std::uint32_t sleep_sec, std::uint32_t sleep_nsec)
     {
         std::chrono::system_clock::time_point wakeup_time(get_wakeup_time(sleep_sec, sleep_nsec));
         wakeup_condition.wait_until(wakeup_lock, wakeup_time);
@@ -138,8 +138,8 @@ protected:
      *
      * @return boost::system_time time to wake up from sleep
      */
-    static std::chrono::system_clock::time_point get_wakeup_time(uint32_t sleep_sec,
-        uint32_t sleep_nsec);
+    static std::chrono::system_clock::time_point get_wakeup_time(std::uint32_t sleep_sec,
+        std::uint32_t sleep_nsec);
 
     /// stops all services used to schedule work
     virtual void stop_services(void) {}
@@ -155,16 +155,16 @@ protected:
     
     
     /// default number of worker threads in the thread pool
-    static const uint32_t    DEFAULT_NUM_THREADS;
+    static const std::uint32_t    DEFAULT_NUM_THREADS;
 
     /// number of nanoseconds in one full second (10 ^ 9)
-    static const uint32_t    NSEC_IN_SECOND;
+    static const std::uint32_t    NSEC_IN_SECOND;
 
     /// number of microseconds in one full second (10 ^ 6)
-    static const uint32_t    MICROSEC_IN_SECOND;
+    static const std::uint32_t    MICROSEC_IN_SECOND;
     
     /// number of seconds a timer should wait for to keep the IO services running
-    static const uint32_t    KEEP_RUNNING_TIMER_SECONDS;
+    static const std::uint32_t    KEEP_RUNNING_TIMER_SECONDS;
 
 
     /// mutex to make class thread-safe
@@ -180,10 +180,10 @@ protected:
     std::condition_variable                m_scheduler_has_stopped;
 
     /// total number of worker threads in the pool
-    uint32_t                 m_num_threads;
+    std::uint32_t                 m_num_threads;
 
     /// the scheduler will not shutdown until there are no more active users
-    uint32_t                 m_active_users;
+    std::uint32_t                 m_active_users;
 
     /// true if the thread scheduler is running
     bool                            m_is_running;
@@ -312,7 +312,7 @@ public:
      *
      * @param n integer number representing the service object
      */
-    virtual asio::io_service& get_io_service(uint32_t n) {
+    virtual asio::io_service& get_io_service(std::uint32_t n) {
         BOOST_ASSERT(n < m_num_threads);
         BOOST_ASSERT(n < m_service_pool.size());
         return m_service_pool[n]->first;
@@ -350,7 +350,7 @@ protected:
     service_pool_type   m_service_pool;
 
     /// the next service to use for scheduling work
-    uint32_t     m_next_service;
+    std::uint32_t     m_next_service;
 };
     
     

--- a/include/pion/spdy/decompressor.hpp
+++ b/include/pion/spdy/decompressor.hpp
@@ -85,7 +85,7 @@ private:
 };
     
 /// data type for a spdy reader pointer
-typedef boost::shared_ptr<decompressor>       decompressor_ptr;
+typedef std::shared_ptr<decompressor>       decompressor_ptr;
     
 }   // end namespace spdy
 }   // end namespace pion

--- a/include/pion/spdy/decompressor.hpp
+++ b/include/pion/spdy/decompressor.hpp
@@ -47,9 +47,9 @@ public:
      * @return the uncompressed string, or null on failure
      */
     char* decompress(const char *compressed_data_ptr,
-                     uint32_t stream_id,
+                     std::uint32_t stream_id,
                      const spdy_control_frame_info& frame,
-                     uint32_t header_block_length);
+                     std::uint32_t header_block_length);
 
     
 protected:
@@ -61,8 +61,8 @@ protected:
      */
     bool spdy_decompress_header(const char *compressed_data_ptr,
                                 z_streamp decomp,
-                                uint32_t length,
-                                uint32_t& uncomp_length);
+                                std::uint32_t length,
+                                std::uint32_t& uncomp_length);
 
 
 private:
@@ -74,10 +74,10 @@ private:
     z_streamp                           m_response_zstream;
     
     /// dictionary identifier
-    uint32_t                     m_dictionary_id;
+    std::uint32_t                     m_dictionary_id;
     
     /// Used for decompressing spdy headers
-    uint8_t                      m_uncompressed_header[MAX_UNCOMPRESSED_DATA_BUF_SIZE];
+    std::uint8_t                      m_uncompressed_header[MAX_UNCOMPRESSED_DATA_BUF_SIZE];
 
     // SPDY Dictionary used for zlib decompression
     static const char                   SPDY_ZLIB_DICTIONARY[];

--- a/include/pion/spdy/decompressor.hpp
+++ b/include/pion/spdy/decompressor.hpp
@@ -12,7 +12,6 @@
 
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <pion/config.hpp>
 #include <pion/spdy/types.hpp>
 #include <zlib.h>

--- a/include/pion/spdy/decompressor.hpp
+++ b/include/pion/spdy/decompressor.hpp
@@ -48,9 +48,9 @@ public:
      * @return the uncompressed string, or null on failure
      */
     char* decompress(const char *compressed_data_ptr,
-                     boost::uint32_t stream_id,
+                     uint32_t stream_id,
                      const spdy_control_frame_info& frame,
-                     boost::uint32_t header_block_length);
+                     uint32_t header_block_length);
 
     
 protected:
@@ -62,8 +62,8 @@ protected:
      */
     bool spdy_decompress_header(const char *compressed_data_ptr,
                                 z_streamp decomp,
-                                boost::uint32_t length,
-                                boost::uint32_t& uncomp_length);
+                                uint32_t length,
+                                uint32_t& uncomp_length);
 
 
 private:
@@ -75,10 +75,10 @@ private:
     z_streamp                           m_response_zstream;
     
     /// dictionary identifier
-    boost::uint32_t                     m_dictionary_id;
+    uint32_t                     m_dictionary_id;
     
     /// Used for decompressing spdy headers
-    boost::uint8_t                      m_uncompressed_header[MAX_UNCOMPRESSED_DATA_BUF_SIZE];
+    uint8_t                      m_uncompressed_header[MAX_UNCOMPRESSED_DATA_BUF_SIZE];
 
     // SPDY Dictionary used for zlib decompression
     static const char                   SPDY_ZLIB_DICTIONARY[];

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -90,8 +90,8 @@ public:
                          asio::error_code& ec,
                          const decompressor_ptr& decompressor,
                          const char *packet_ptr,
-                         boost::uint32_t& length_packet,
-                         boost::uint32_t current_stream_count);
+                         uint32_t& length_packet,
+                         uint32_t current_stream_count);
     
     /// Get the pointer to the first character to the spdy data contect 
     const char * get_spdy_data_content( ) { return m_last_data_chunk_ptr; }
@@ -118,7 +118,7 @@ public:
      *
      * @return true if it is a control frame else returns false
      */
-    static boost::uint32_t get_control_frame_stream_id(const char *ptr);
+    static uint32_t get_control_frame_stream_id(const char *ptr);
     
     
 protected:
@@ -130,8 +130,8 @@ protected:
     /// Returns false if there was an error else returns true
     bool populate_frame(asio::error_code& ec,
                         spdy_control_frame_info& frame,
-                        boost::uint32_t& length_packet,
-                        boost::uint32_t& stream_id,
+                        uint32_t& length_packet,
+                        uint32_t& stream_id,
                         http_protocol_info& http_headers);
     
     /// creates the unique parser error_category_t
@@ -161,7 +161,7 @@ protected:
                               const decompressor_ptr& decompressor,
                               const spdy_control_frame_info& frame,
                               http_protocol_info& http_headers,
-                              boost::uint32_t current_stream_count);
+                              uint32_t current_stream_count);
     
     /**
      * parses the data for SPDY
@@ -169,7 +169,7 @@ protected:
      */
     void parse_spdy_data(asio::error_code& ec,
                          const spdy_control_frame_info& frame,
-                         boost::uint32_t stream_id,
+                         uint32_t stream_id,
                          http_protocol_info& http_info);
     
     /**
@@ -218,8 +218,8 @@ protected:
     boost::tribool parse_spdy_frame(asio::error_code& ec,
                                     const decompressor_ptr& decompressor,
                                     http_protocol_info& http_headers,
-                                    boost::uint32_t& length_packet,
-                                    boost::uint32_t current_stream_count);
+                                    uint32_t& length_packet,
+                                    uint32_t current_stream_count);
     
 private:
     

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -88,7 +88,7 @@ public:
      *                        indeterminate = not yet finished parsing SPDY frame
      */
     boost::tribool parse(http_protocol_info& http_headers,
-                         boost::system::error_code& ec,
+                         asio::error_code& ec,
                          const decompressor_ptr& decompressor,
                          const char *packet_ptr,
                          boost::uint32_t& length_packet,
@@ -129,7 +129,7 @@ protected:
     
     /// populates the frame for every spdy packet
     /// Returns false if there was an error else returns true
-    bool populate_frame(boost::system::error_code& ec,
+    bool populate_frame(asio::error_code& ec,
                         spdy_control_frame_info& frame,
                         boost::uint32_t& length_packet,
                         boost::uint32_t& stream_id,
@@ -150,15 +150,15 @@ protected:
      * @param ec error code variable to define
      * @param ev error value to raise
      */
-    static inline void set_error(boost::system::error_code& ec, error_value_t ev) {
-        ec = boost::system::error_code(static_cast<int>(ev), get_error_category());
+    static inline void set_error(asio::error_code& ec, error_value_t ev) {
+        ec = asio::error_code(static_cast<int>(ev), get_error_category());
     }
     
     /**
      * parses an the header payload for SPDY
      *
      */
-    void parse_header_payload(boost::system::error_code& ec,
+    void parse_header_payload(asio::error_code& ec,
                               const decompressor_ptr& decompressor,
                               const spdy_control_frame_info& frame,
                               http_protocol_info& http_headers,
@@ -168,7 +168,7 @@ protected:
      * parses the data for SPDY
      *
      */
-    void parse_spdy_data(boost::system::error_code& ec,
+    void parse_spdy_data(asio::error_code& ec,
                          const spdy_control_frame_info& frame,
                          boost::uint32_t stream_id,
                          http_protocol_info& http_info);
@@ -177,35 +177,35 @@ protected:
      * parses an the Settings Frame for SPDY
      *
      */
-    void parse_spdy_settings_frame(boost::system::error_code& ec,
+    void parse_spdy_settings_frame(asio::error_code& ec,
                                    const spdy_control_frame_info& frame);
     
     /**
      * parses an the RST stream for SPDY
      *
      */
-    void parse_spdy_rst_stream(boost::system::error_code& ec,
+    void parse_spdy_rst_stream(asio::error_code& ec,
                                const spdy_control_frame_info& frame);
     
     /**
      * parses an the Ping Frame for SPDY
      *
      */
-    void parse_spdy_ping_frame(boost::system::error_code& ec,
+    void parse_spdy_ping_frame(asio::error_code& ec,
                                const spdy_control_frame_info& frame);
     
     /**
      * parses an the GoAway Frame for SPDY
      *
      */
-    void parse_spdy_goaway_frame(boost::system::error_code& ec,
+    void parse_spdy_goaway_frame(asio::error_code& ec,
                                  const spdy_control_frame_info& frame);
     
     /**
      * parses an the WindowUpdate Frame for SPDY
      *
      */
-    void parse_spdy_window_update_frame(boost::system::error_code& ec,
+    void parse_spdy_window_update_frame(asio::error_code& ec,
                                         const spdy_control_frame_info& frame);
     
     /**
@@ -216,7 +216,7 @@ protected:
      *                        true = finished parsing SPDY frame,
      *                        indeterminate = not yet finished parsing SPDY frame
      */
-    boost::tribool parse_spdy_frame(boost::system::error_code& ec,
+    boost::tribool parse_spdy_frame(asio::error_code& ec,
                                     const decompressor_ptr& decompressor,
                                     http_protocol_info& http_headers,
                                     boost::uint32_t& length_packet,
@@ -247,7 +247,7 @@ private:
 };
 
 /// data type for a spdy reader pointer
-typedef boost::shared_ptr<parser>       parser_ptr;
+typedef std::shared_ptr<parser>       parser_ptr;
         
         
 }   // end namespace spdy

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -10,11 +10,10 @@
 #ifndef __PION_SPDYPARSER_HEADER__
 #define __PION_SPDYPARSER_HEADER__
 
-
-#include <boost/shared_ptr.hpp>
+#include <memory>
+#include <thread>
 #include <boost/logic/tribool.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/thread/once.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/spdy/types.hpp>
@@ -140,7 +139,7 @@ protected:
     
     /// returns an instance of parser::error_category_t
     static inline error_category_t& get_error_category(void) {
-        boost::call_once(parser::create_error_category, m_instance_flag);
+        std::call_once(m_instance_flag, parser::create_error_category);
         return *m_error_category_ptr;
     }
 
@@ -243,7 +242,7 @@ private:
     static error_category_t *           m_error_category_ptr;
     
     /// used to ensure thread safety of the HTTPParser ErrorCategory
-    static boost::once_flag             m_instance_flag;
+    static std::once_flag             m_instance_flag;
 };
 
 /// data type for a spdy reader pointer

--- a/include/pion/spdy/parser.hpp
+++ b/include/pion/spdy/parser.hpp
@@ -90,8 +90,8 @@ public:
                          asio::error_code& ec,
                          const decompressor_ptr& decompressor,
                          const char *packet_ptr,
-                         uint32_t& length_packet,
-                         uint32_t current_stream_count);
+                         std::uint32_t& length_packet,
+                         std::uint32_t current_stream_count);
     
     /// Get the pointer to the first character to the spdy data contect 
     const char * get_spdy_data_content( ) { return m_last_data_chunk_ptr; }
@@ -118,7 +118,7 @@ public:
      *
      * @return true if it is a control frame else returns false
      */
-    static uint32_t get_control_frame_stream_id(const char *ptr);
+    static std::uint32_t get_control_frame_stream_id(const char *ptr);
     
     
 protected:
@@ -130,8 +130,8 @@ protected:
     /// Returns false if there was an error else returns true
     bool populate_frame(asio::error_code& ec,
                         spdy_control_frame_info& frame,
-                        uint32_t& length_packet,
-                        uint32_t& stream_id,
+                        std::uint32_t& length_packet,
+                        std::uint32_t& stream_id,
                         http_protocol_info& http_headers);
     
     /// creates the unique parser error_category_t
@@ -161,7 +161,7 @@ protected:
                               const decompressor_ptr& decompressor,
                               const spdy_control_frame_info& frame,
                               http_protocol_info& http_headers,
-                              uint32_t current_stream_count);
+                              std::uint32_t current_stream_count);
     
     /**
      * parses the data for SPDY
@@ -169,7 +169,7 @@ protected:
      */
     void parse_spdy_data(asio::error_code& ec,
                          const spdy_control_frame_info& frame,
-                         uint32_t stream_id,
+                         std::uint32_t stream_id,
                          http_protocol_info& http_info);
     
     /**
@@ -218,8 +218,8 @@ protected:
     boost::tribool parse_spdy_frame(asio::error_code& ec,
                                     const decompressor_ptr& decompressor,
                                     http_protocol_info& http_headers,
-                                    uint32_t& length_packet,
-                                    uint32_t current_stream_count);
+                                    std::uint32_t& length_packet,
+                                    std::uint32_t current_stream_count);
     
 private:
     

--- a/include/pion/spdy/types.hpp
+++ b/include/pion/spdy/types.hpp
@@ -47,10 +47,10 @@ namespace spdy {    // begin namespace spdy
 /// This structure will be tied to each SPDY frame
 typedef struct spdy_control_frame_info{
     bool control_bit;
-    uint16_t  version;
-    uint16_t  type;
-    uint8_t   flags;
-    uint32_t  length;  // Actually only 24 bits.
+    std::uint16_t  version;
+    std::uint16_t  type;
+    std::uint8_t   flags;
+    std::uint32_t  length;  // Actually only 24 bits.
 } spdy_control_frame_info;
 
     
@@ -58,20 +58,20 @@ typedef struct spdy_control_frame_info{
 /// Only applies to frames containing headers: SYN_STREAM, SYN_REPLY, HEADERS
 /// Note that there may be multiple SPDY frames in one packet.
 typedef struct _spdy_header_info{
-    uint32_t stream_id;
-    uint8_t *header_block;
-    uint8_t  header_block_len;
-    uint16_t frame_type;
+    std::uint32_t stream_id;
+    std::uint8_t *header_block;
+    std::uint8_t  header_block_len;
+    std::uint16_t frame_type;
 } spdy_header_info;
 
 
 /// This structure contains the HTTP Protocol information
 typedef struct _http_protocol_info_t{
     std::map<std::string, std::string> http_headers;
-    uint32_t     http_type;
-    uint32_t     stream_id;
-    uint32_t     data_offset;
-    uint32_t     data_size;
+    std::uint32_t     http_type;
+    std::uint32_t     stream_id;
+    std::uint32_t     data_offset;
+    std::uint32_t     data_size;
     bool                last_chunk;
     
     _http_protocol_info_t()

--- a/include/pion/spdy/types.hpp
+++ b/include/pion/spdy/types.hpp
@@ -47,10 +47,10 @@ namespace spdy {    // begin namespace spdy
 /// This structure will be tied to each SPDY frame
 typedef struct spdy_control_frame_info{
     bool control_bit;
-    boost::uint16_t  version;
-    boost::uint16_t  type;
-    boost::uint8_t   flags;
-    boost::uint32_t  length;  // Actually only 24 bits.
+    uint16_t  version;
+    uint16_t  type;
+    uint8_t   flags;
+    uint32_t  length;  // Actually only 24 bits.
 } spdy_control_frame_info;
 
     
@@ -58,20 +58,20 @@ typedef struct spdy_control_frame_info{
 /// Only applies to frames containing headers: SYN_STREAM, SYN_REPLY, HEADERS
 /// Note that there may be multiple SPDY frames in one packet.
 typedef struct _spdy_header_info{
-    boost::uint32_t stream_id;
-    boost::uint8_t *header_block;
-    boost::uint8_t  header_block_len;
-    boost::uint16_t frame_type;
+    uint32_t stream_id;
+    uint8_t *header_block;
+    uint8_t  header_block_len;
+    uint16_t frame_type;
 } spdy_header_info;
 
 
 /// This structure contains the HTTP Protocol information
 typedef struct _http_protocol_info_t{
     std::map<std::string, std::string> http_headers;
-    boost::uint32_t     http_type;
-    boost::uint32_t     stream_id;
-    boost::uint32_t     data_offset;
-    boost::uint32_t     data_size;
+    uint32_t     http_type;
+    uint32_t     stream_id;
+    uint32_t     data_offset;
+    uint32_t     data_size;
     bool                last_chunk;
     
     _http_protocol_info_t()

--- a/include/pion/tcp/connection.hpp
+++ b/include/pion/tcp/connection.hpp
@@ -18,14 +18,12 @@
     #include <boost/asio/ssl.hpp>
 #endif
 
+#include <memory>
+#include <functional>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/asio.hpp>
+#include <asio.hpp>
+#include <asio/ssl.hpp>
 #include <boost/array.hpp>
-#include <boost/function.hpp>
-#include <boost/function/function1.hpp>
 #include <pion/config.hpp>
 #include <string>
 
@@ -38,7 +36,7 @@ namespace tcp {     // begin namespace tcp
 /// connection: represents a single tcp connection
 /// 
 class connection :
-    public boost::enable_shared_from_this<connection>,
+    public std::enable_shared_from_this<connection>,
     private boost::noncopyable
 {
 public:
@@ -52,24 +50,24 @@ public:
     enum { READ_BUFFER_SIZE = 8192 };
     
     /// data type for a function that handles TCP connection objects
-    typedef boost::function1<void, boost::shared_ptr<connection> >   connection_handler;
+    typedef std::function<void(std::shared_ptr<connection>)>   connection_handler;
     
     /// data type for an I/O read buffer
     typedef boost::array<char, READ_BUFFER_SIZE>    read_buffer_type;
     
     /// data type for a socket connection
-    typedef boost::asio::ip::tcp::socket            socket_type;
+    typedef asio::ip::tcp::socket            socket_type;
 
 #ifdef PION_HAVE_SSL
     /// data type for an SSL socket connection
-    typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket>  ssl_socket_type;
+    typedef asio::ssl::stream<asio::ip::tcp::socket>  ssl_socket_type;
 
     /// data type for SSL configuration context
-    typedef boost::asio::ssl::context                               ssl_context_type;
+    typedef asio::ssl::context                               ssl_context_type;
 #else
     class ssl_socket_type {
     public:
-        ssl_socket_type(boost::asio::io_service& io_service) : m_socket(io_service) {}
+        ssl_socket_type(asio::io_service& io_service) : m_socket(io_service) {}
         inline socket_type& next_layer(void) { return m_socket; }
         inline const socket_type& next_layer(void) const { return m_socket; }
         inline socket_type::lowest_layer_type& lowest_layer(void) { return m_socket.lowest_layer(); }
@@ -91,12 +89,12 @@ public:
      * @param finished_handler function called when a server has finished
      *                         handling the connection
      */
-    static inline boost::shared_ptr<connection> create(boost::asio::io_service& io_service,
+    static inline std::shared_ptr<connection> create(asio::io_service& io_service,
                                                           ssl_context_type& ssl_context,
                                                           const bool ssl_flag,
                                                           connection_handler finished_handler)
     {
-        return boost::shared_ptr<connection>(new connection(io_service, ssl_context,
+        return std::shared_ptr<connection>(new connection(io_service, ssl_context,
                                                                   ssl_flag, finished_handler));
     }
     
@@ -106,10 +104,10 @@ public:
      * @param io_service asio service associated with the connection
      * @param ssl_flag if true then the connection will be encrypted using SSL 
      */
-    explicit connection(boost::asio::io_service& io_service, const bool ssl_flag = false)
+    explicit connection(asio::io_service& io_service, const bool ssl_flag = false)
         :
 #ifdef PION_HAVE_SSL
-        m_ssl_context(io_service, boost::asio::ssl::context::sslv23),
+        m_ssl_context(io_service, asio::ssl::context::sslv23),
         m_ssl_socket(io_service, m_ssl_context),
         m_ssl_flag(ssl_flag),
 #else
@@ -128,10 +126,10 @@ public:
      * @param io_service asio service associated with the connection
      * @param ssl_context asio ssl context associated with the connection
      */
-    connection(boost::asio::io_service& io_service, ssl_context_type& ssl_context)
+    connection(asio::io_service& io_service, ssl_context_type& ssl_context)
         :
 #ifdef PION_HAVE_SSL
-        m_ssl_context(io_service, boost::asio::ssl::context::sslv23),
+        m_ssl_context(io_service, asio::ssl::context::sslv23),
         m_ssl_socket(io_service, ssl_context), m_ssl_flag(true),
 #else
         m_ssl_context(0),
@@ -158,12 +156,12 @@ public:
 
                 // windows seems to require this otherwise it doesn't
                 // recognize that connections have been closed
-                m_ssl_socket.next_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+                m_ssl_socket.next_layer().shutdown(asio::ip::tcp::socket::shutdown_both);
                 
             } catch (...) {}    // ignore exceptions
             
             // close the underlying socket (ignore errors)
-            boost::system::error_code ec;
+            asio::error_code ec;
             m_ssl_socket.next_layer().close(ec);
         }
     }
@@ -175,7 +173,7 @@ public:
     /// and the suggested #define statements cause WAY too much trouble and heartache
     inline void cancel(void) {
 #if !defined(_MSC_VER) || (_WIN32_WINNT >= 0x0600)
-        boost::system::error_code ec;
+        asio::error_code ec;
         m_ssl_socket.next_layer().cancel(ec);
 #endif
     }
@@ -189,10 +187,10 @@ public:
      * @param tcp_acceptor object used to accept new connections
      * @param handler called after a new connection has been accepted
      *
-     * @see boost::asio::basic_socket_acceptor::async_accept()
+     * @see asio::basic_socket_acceptor::async_accept()
      */
     template <typename AcceptHandler>
-    inline void async_accept(boost::asio::ip::tcp::acceptor& tcp_acceptor,
+    inline void async_accept(asio::ip::tcp::acceptor& tcp_acceptor,
                              AcceptHandler handler)
     {
         tcp_acceptor.async_accept(m_ssl_socket.lowest_layer(), handler);
@@ -202,13 +200,13 @@ public:
      * accepts a new tcp connection (blocks until established)
      *
      * @param tcp_acceptor object used to accept new connections
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return asio::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::accept()
+     * @see asio::basic_socket_acceptor::accept()
      */
-    inline boost::system::error_code accept(boost::asio::ip::tcp::acceptor& tcp_acceptor)
+    inline asio::error_code accept(asio::ip::tcp::acceptor& tcp_acceptor)
     {
-        boost::system::error_code ec;
+        asio::error_code ec;
         tcp_acceptor.accept(m_ssl_socket.lowest_layer(), ec);
         return ec;
     }
@@ -219,10 +217,10 @@ public:
      * @param tcp_endpoint remote endpoint to connect to
      * @param handler called after a new connection has been established
      *
-     * @see boost::asio::basic_socket_acceptor::async_connect()
+     * @see asio::basic_socket_acceptor::async_connect()
      */
     template <typename ConnectHandler>
-    inline void async_connect(const boost::asio::ip::tcp::endpoint& tcp_endpoint,
+    inline void async_connect(const asio::ip::tcp::endpoint& tcp_endpoint,
                               ConnectHandler handler)
     {
         m_ssl_socket.lowest_layer().async_connect(tcp_endpoint, handler);
@@ -235,14 +233,14 @@ public:
      * @param remote_port remote port number to connect to
      * @param handler called after a new connection has been established
      *
-     * @see boost::asio::basic_socket_acceptor::async_connect()
+     * @see asio::basic_socket_acceptor::async_connect()
      */
     template <typename ConnectHandler>
-    inline void async_connect(const boost::asio::ip::address& remote_addr,
+    inline void async_connect(const asio::ip::address& remote_addr,
                               const unsigned int remote_port,
                               ConnectHandler handler)
     {
-        boost::asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
+        asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
         async_connect(tcp_endpoint, handler);
     }
     
@@ -250,13 +248,13 @@ public:
      * connects to a remote endpoint (blocks until established)
      *
      * @param tcp_endpoint remote endpoint to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return asio::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::connect()
+     * @see asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(boost::asio::ip::tcp::endpoint& tcp_endpoint)
+    inline asio::error_code connect(asio::ip::tcp::endpoint& tcp_endpoint)
     {
-        boost::system::error_code ec;
+        asio::error_code ec;
         m_ssl_socket.lowest_layer().connect(tcp_endpoint, ec);
         return ec;
     }
@@ -266,14 +264,14 @@ public:
      *
      * @param remote_addr remote IP address (v4) to connect to
      * @param remote_port remote port number to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return asio::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::connect()
+     * @see asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(const boost::asio::ip::address& remote_addr,
+    inline asio::error_code connect(const asio::ip::address& remote_addr,
                                              const unsigned int remote_port)
     {
-        boost::asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
+        asio::ip::tcp::endpoint tcp_endpoint(remote_addr, remote_port);
         return connect(tcp_endpoint);
     }
     
@@ -282,28 +280,28 @@ public:
      *
      * @param remote_server hostname of the remote server to connect to
      * @param remote_port remote port number to connect to
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return asio::error_code contains error code if the connection fails
      *
-     * @see boost::asio::basic_socket_acceptor::connect()
+     * @see asio::basic_socket_acceptor::connect()
      */
-    inline boost::system::error_code connect(const std::string& remote_server,
+    inline asio::error_code connect(const std::string& remote_server,
                                              const unsigned int remote_port)
     {
         // query a list of matching endpoints
-        boost::system::error_code ec;
-        boost::asio::ip::tcp::resolver resolver(m_ssl_socket.lowest_layer().get_io_service());
-        boost::asio::ip::tcp::resolver::query query(remote_server,
-            boost::lexical_cast<std::string>(remote_port),
-            boost::asio::ip::tcp::resolver::query::numeric_service);
-        boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query, ec);
+        asio::error_code ec;
+        asio::ip::tcp::resolver resolver(m_ssl_socket.lowest_layer().get_io_service());
+        asio::ip::tcp::resolver::query query(remote_server,
+        std::to_string(remote_port),
+            asio::ip::tcp::resolver::query::numeric_service);
+        asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query, ec);
         if (ec)
             return ec;
 
         // try each one until we are successful
-        ec = boost::asio::error::host_not_found;
-        boost::asio::ip::tcp::resolver::iterator end;
+        ec = asio::error::host_not_found;
+        asio::ip::tcp::resolver::iterator end;
         while (ec && endpoint_iterator != end) {
-            boost::asio::ip::tcp::endpoint ep(endpoint_iterator->endpoint());
+            asio::ip::tcp::endpoint ep(endpoint_iterator->endpoint());
             ++endpoint_iterator;
             ec = connect(ep);
             if (ec)
@@ -318,12 +316,12 @@ public:
      *
      * @param handler called after the ssl handshake has completed
      *
-     * @see boost::asio::ssl::stream::async_handshake()
+     * @see asio::ssl::stream::async_handshake()
      */
     template <typename SSLHandshakeHandler>
     inline void async_handshake_client(SSLHandshakeHandler handler) {
 #ifdef PION_HAVE_SSL
-        m_ssl_socket.async_handshake(boost::asio::ssl::stream_base::client, handler);
+        m_ssl_socket.async_handshake(asio::ssl::stream_base::client, handler);
         m_ssl_flag = true;
 #endif
     }
@@ -333,12 +331,12 @@ public:
      *
      * @param handler called after the ssl handshake has completed
      *
-     * @see boost::asio::ssl::stream::async_handshake()
+     * @see asio::ssl::stream::async_handshake()
      */
     template <typename SSLHandshakeHandler>
     inline void async_handshake_server(SSLHandshakeHandler handler) {
 #ifdef PION_HAVE_SSL
-        m_ssl_socket.async_handshake(boost::asio::ssl::stream_base::server, handler);
+        m_ssl_socket.async_handshake(asio::ssl::stream_base::server, handler);
         m_ssl_flag = true;
 #endif
     }
@@ -346,14 +344,14 @@ public:
     /**
      * performs client-side SSL handshake for a new connection (blocks until finished)
      *
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return asio::error_code contains error code if the connection fails
      *
-     * @see boost::asio::ssl::stream::handshake()
+     * @see asio::ssl::stream::handshake()
      */
-    inline boost::system::error_code handshake_client(void) {
-        boost::system::error_code ec;
+    inline asio::error_code handshake_client(void) {
+        asio::error_code ec;
 #ifdef PION_HAVE_SSL
-        m_ssl_socket.handshake(boost::asio::ssl::stream_base::client, ec);
+        m_ssl_socket.handshake(asio::ssl::stream_base::client, ec);
         m_ssl_flag = true;
 #endif
         return ec;
@@ -362,14 +360,14 @@ public:
     /**
      * performs server-side SSL handshake for a new connection (blocks until finished)
      *
-     * @return boost::system::error_code contains error code if the connection fails
+     * @return asio::error_code contains error code if the connection fails
      *
-     * @see boost::asio::ssl::stream::handshake()
+     * @see asio::ssl::stream::handshake()
      */
-    inline boost::system::error_code handshake_server(void) {
-        boost::system::error_code ec;
+    inline asio::error_code handshake_server(void) {
+        asio::error_code ec;
 #ifdef PION_HAVE_SSL
-        m_ssl_socket.handshake(boost::asio::ssl::stream_base::server, ec);
+        m_ssl_socket.handshake(asio::ssl::stream_base::server, ec);
         m_ssl_flag = true;
 #endif
         return ec;
@@ -380,17 +378,17 @@ public:
      *
      * @param handler called after the read operation has completed
      *
-     * @see boost::asio::basic_stream_socket::async_read_some()
+     * @see asio::basic_stream_socket::async_read_some()
      */
     template <typename ReadHandler>
     inline void async_read_some(ReadHandler handler) {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            m_ssl_socket.async_read_some(boost::asio::buffer(m_read_buffer),
+            m_ssl_socket.async_read_some(asio::buffer(m_read_buffer),
                                          handler);
         else
 #endif      
-            m_ssl_socket.next_layer().async_read_some(boost::asio::buffer(m_read_buffer),
+            m_ssl_socket.next_layer().async_read_some(asio::buffer(m_read_buffer),
                                          handler);
     }
     
@@ -400,7 +398,7 @@ public:
      * @param read_buffer the buffer to read data into
      * @param handler called after the read operation has completed
      *
-     * @see boost::asio::basic_stream_socket::async_read_some()
+     * @see asio::basic_stream_socket::async_read_some()
      */
     template <typename ReadBufferType, typename ReadHandler>
     inline void async_read_some(ReadBufferType read_buffer,
@@ -419,15 +417,15 @@ public:
      * @param ec contains error code if the read fails
      * @return std::size_t number of bytes read
      *
-     * @see boost::asio::basic_stream_socket::read_some()
+     * @see asio::basic_stream_socket::read_some()
      */
-    inline std::size_t read_some(boost::system::error_code& ec) {
+    inline std::size_t read_some(asio::error_code& ec) {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            return m_ssl_socket.read_some(boost::asio::buffer(m_read_buffer), ec);
+            return m_ssl_socket.read_some(asio::buffer(m_read_buffer), ec);
         else
 #endif      
-            return m_ssl_socket.next_layer().read_some(boost::asio::buffer(m_read_buffer), ec);
+            return m_ssl_socket.next_layer().read_some(asio::buffer(m_read_buffer), ec);
     }
     
     /**
@@ -437,11 +435,11 @@ public:
      * @param ec contains error code if the read fails
      * @return std::size_t number of bytes read
      *
-     * @see boost::asio::basic_stream_socket::read_some()
+     * @see asio::basic_stream_socket::read_some()
      */
     template <typename ReadBufferType>
     inline std::size_t read_some(ReadBufferType read_buffer,
-                                 boost::system::error_code& ec)
+                                 asio::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
@@ -458,7 +456,7 @@ public:
      * @param completion_condition determines if the read operation is complete
      * @param handler called after the read operation has completed
      *
-     * @see boost::asio::async_read()
+     * @see asio::async_read()
      */
     template <typename CompletionCondition, typename ReadHandler>
     inline void async_read(CompletionCondition completion_condition,
@@ -466,11 +464,11 @@ public:
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            boost::asio::async_read(m_ssl_socket, boost::asio::buffer(m_read_buffer),
+            asio::async_read(m_ssl_socket, asio::buffer(m_read_buffer),
                                     completion_condition, handler);
         else
 #endif      
-            boost::asio::async_read(m_ssl_socket.next_layer(), boost::asio::buffer(m_read_buffer),
+            asio::async_read(m_ssl_socket.next_layer(), asio::buffer(m_read_buffer),
                                     completion_condition, handler);
     }
             
@@ -482,7 +480,7 @@ public:
      * @param completion_condition determines if the read operation is complete
      * @param handler called after the read operation has completed
      *
-     * @see boost::asio::async_read()
+     * @see asio::async_read()
      */
     template <typename MutableBufferSequence, typename CompletionCondition, typename ReadHandler>
     inline void async_read(const MutableBufferSequence& buffers,
@@ -491,11 +489,11 @@ public:
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            boost::asio::async_read(m_ssl_socket, buffers,
+            asio::async_read(m_ssl_socket, buffers,
                                     completion_condition, handler);
         else
 #endif      
-            boost::asio::async_read(m_ssl_socket.next_layer(), buffers,
+            asio::async_read(m_ssl_socket.next_layer(), buffers,
                                     completion_condition, handler);
     }
     
@@ -507,19 +505,19 @@ public:
      * @param ec contains error code if the read fails
      * @return std::size_t number of bytes read
      *
-     * @see boost::asio::read()
+     * @see asio::read()
      */
     template <typename CompletionCondition>
     inline std::size_t read(CompletionCondition completion_condition,
-                            boost::system::error_code& ec)
+                            asio::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            return boost::asio::async_read(m_ssl_socket, boost::asio::buffer(m_read_buffer),
+            return asio::async_read(m_ssl_socket, asio::buffer(m_read_buffer),
                                            completion_condition, ec);
         else
 #endif      
-            return boost::asio::async_read(m_ssl_socket.next_layer(), boost::asio::buffer(m_read_buffer),
+            return asio::async_read(m_ssl_socket.next_layer(), asio::buffer(m_read_buffer),
                                            completion_condition, ec);
     }
     
@@ -532,20 +530,20 @@ public:
      * @param ec contains error code if the read fails
      * @return std::size_t number of bytes read
      *
-     * @see boost::asio::read()
+     * @see asio::read()
      */
     template <typename MutableBufferSequence, typename CompletionCondition>
     inline std::size_t read(const MutableBufferSequence& buffers,
                             CompletionCondition completion_condition,
-                            boost::system::error_code& ec)
+                            asio::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            return boost::asio::read(m_ssl_socket, buffers,
+            return asio::read(m_ssl_socket, buffers,
                                      completion_condition, ec);
         else
 #endif      
-            return boost::asio::read(m_ssl_socket.next_layer(), buffers,
+            return asio::read(m_ssl_socket.next_layer(), buffers,
                                      completion_condition, ec);
     }
     
@@ -555,16 +553,16 @@ public:
      * @param buffers one or more buffers containing the data to be written
      * @param handler called after the data has been written
      *
-     * @see boost::asio::async_write()
+     * @see asio::async_write()
      */
     template <typename ConstBufferSequence, typename write_handler_t>
     inline void async_write(const ConstBufferSequence& buffers, write_handler_t handler) {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            boost::asio::async_write(m_ssl_socket, buffers, handler);
+            asio::async_write(m_ssl_socket, buffers, handler);
         else
 #endif      
-            boost::asio::async_write(m_ssl_socket.next_layer(), buffers, handler);
+            asio::async_write(m_ssl_socket.next_layer(), buffers, handler);
     }   
         
     /**
@@ -574,20 +572,20 @@ public:
      * @param ec contains error code if the write fails
      * @return std::size_t number of bytes written
      *
-     * @see boost::asio::write()
+     * @see asio::write()
      */
     template <typename ConstBufferSequence>
     inline std::size_t write(const ConstBufferSequence& buffers,
-                             boost::system::error_code& ec)
+                             asio::error_code& ec)
     {
 #ifdef PION_HAVE_SSL
         if (get_ssl_flag())
-            return boost::asio::write(m_ssl_socket, buffers,
-                                      boost::asio::transfer_all(), ec);
+            return asio::write(m_ssl_socket, buffers,
+                                      asio::transfer_all(), ec);
         else
 #endif      
-            return boost::asio::write(m_ssl_socket.next_layer(), buffers,
-                                      boost::asio::transfer_all(), ec);
+            return asio::write(m_ssl_socket.next_layer(), buffers,
+                                      asio::transfer_all(), ec);
     }   
     
     
@@ -636,8 +634,8 @@ public:
     }
 
     /// returns an ASIO endpoint for the client connection
-    inline boost::asio::ip::tcp::endpoint get_remote_endpoint(void) const {
-        boost::asio::ip::tcp::endpoint remote_endpoint;
+    inline asio::ip::tcp::endpoint get_remote_endpoint(void) const {
+        asio::ip::tcp::endpoint remote_endpoint;
         try {
             // const_cast is required since lowest_layer() is only defined non-const in asio
             remote_endpoint = const_cast<ssl_socket_type&>(m_ssl_socket).lowest_layer().remote_endpoint();
@@ -648,7 +646,7 @@ public:
     }
 
     /// returns the client's IP address
-    inline boost::asio::ip::address get_remote_ip(void) const {
+    inline asio::ip::address get_remote_ip(void) const {
         return get_remote_endpoint().address();
     }
 
@@ -658,7 +656,7 @@ public:
     }
     
     /// returns reference to the io_service used for async operations
-    inline boost::asio::io_service& get_io_service(void) {
+    inline asio::io_service& get_io_service(void) {
         return m_ssl_socket.lowest_layer().get_io_service();
     }
 
@@ -686,13 +684,13 @@ protected:
      * @param finished_handler function called when a server has finished
      *                         handling the connection
      */
-    connection(boost::asio::io_service& io_service,
+    connection(asio::io_service& io_service,
                   ssl_context_type& ssl_context,
                   const bool ssl_flag,
                   connection_handler finished_handler)
         :
 #ifdef PION_HAVE_SSL
-        m_ssl_context(io_service, boost::asio::ssl::context::sslv23),
+        m_ssl_context(io_service, asio::ssl::context::sslv23),
         m_ssl_socket(io_service, ssl_context), m_ssl_flag(ssl_flag),
 #else
         m_ssl_context(0),
@@ -735,7 +733,7 @@ private:
 
 
 /// data type for a connection pointer
-typedef boost::shared_ptr<connection>    connection_ptr;
+typedef std::shared_ptr<connection>    connection_ptr;
 
 
 }   // end namespace tcp

--- a/include/pion/tcp/connection.hpp
+++ b/include/pion/tcp/connection.hpp
@@ -20,10 +20,10 @@
 
 #include <memory>
 #include <functional>
+#include <array>
 #include <boost/noncopyable.hpp>
 #include <asio.hpp>
 #include <asio/ssl.hpp>
-#include <boost/array.hpp>
 #include <pion/config.hpp>
 #include <string>
 
@@ -53,7 +53,7 @@ public:
     typedef std::function<void(std::shared_ptr<connection>)>   connection_handler;
     
     /// data type for an I/O read buffer
-    typedef boost::array<char, READ_BUFFER_SIZE>    read_buffer_type;
+    typedef std::array<char, READ_BUFFER_SIZE>    read_buffer_type;
     
     /// data type for a socket connection
     typedef asio::ip::tcp::socket            socket_type;

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -11,11 +11,10 @@
 #define __PION_TCP_SERVER_HEADER__
 
 #include <set>
+#include <mutex>
+#include <condition_variable>
 #include <asio.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/scheduler.hpp>
@@ -214,10 +213,10 @@ private:
     connection::ssl_context_type            m_ssl_context;
         
     /// condition triggered when the server has stopped listening for connections
-    boost::condition                        m_server_has_stopped;
+    std::condition_variable                        m_server_has_stopped;
 
     /// condition triggered when the connection pool is empty
-    boost::condition                        m_no_more_connections;
+    std::condition_variable                        m_no_more_connections;
 
     /// pool of active connections associated with this server 
     ConnectionPool                          m_conn_pool;
@@ -232,7 +231,7 @@ private:
     bool                                    m_is_listening;
 
     /// mutex to make class thread-safe
-    mutable boost::mutex                    m_mutex;
+    mutable std::mutex                    m_mutex;
 };
 
 

--- a/include/pion/tcp/server.hpp
+++ b/include/pion/tcp/server.hpp
@@ -11,7 +11,7 @@
 #define __PION_TCP_SERVER_HEADER__
 
 #include <set>
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
@@ -67,16 +67,16 @@ public:
     inline void set_port(unsigned int p) { m_endpoint.port(p); }
     
     /// returns IP address that the server listens for connections on
-    inline boost::asio::ip::address get_address(void) const { return m_endpoint.address(); }
+    inline asio::ip::address get_address(void) const { return m_endpoint.address(); }
     
     /// sets IP address that the server listens for connections on
-    inline void set_address(const boost::asio::ip::address& addr) { m_endpoint.address(addr); }
+    inline void set_address(const asio::ip::address& addr) { m_endpoint.address(addr); }
     
     /// returns tcp endpoint that the server listens for connections on
-    inline const boost::asio::ip::tcp::endpoint& get_endpoint(void) const { return m_endpoint; }
+    inline const asio::ip::tcp::endpoint& get_endpoint(void) const { return m_endpoint; }
     
     /// sets tcp endpoint that the server listens for connections on
-    inline void set_endpoint(const boost::asio::ip::tcp::endpoint& ep) { m_endpoint = ep; }
+    inline void set_endpoint(const asio::ip::tcp::endpoint& ep) { m_endpoint = ep; }
 
     /// returns true if the server uses SSL to encrypt connections
     inline bool get_ssl_flag(void) const { return m_ssl_flag; }
@@ -97,10 +97,10 @@ public:
     inline logger get_logger(void) { return m_logger; }
     
     /// returns mutable reference to the TCP connection acceptor
-    inline boost::asio::ip::tcp::acceptor& get_acceptor(void) { return m_tcp_acceptor; }
+    inline asio::ip::tcp::acceptor& get_acceptor(void) { return m_tcp_acceptor; }
 
     /// returns const reference to the TCP connection acceptor
-    inline const boost::asio::ip::tcp::acceptor& get_acceptor(void) const { return m_tcp_acceptor; }
+    inline const asio::ip::tcp::acceptor& get_acceptor(void) const { return m_tcp_acceptor; }
 
     
 protected:
@@ -117,7 +117,7 @@ protected:
      * 
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    explicit server(const boost::asio::ip::tcp::endpoint& endpoint);
+    explicit server(const asio::ip::tcp::endpoint& endpoint);
 
     /**
      * protected constructor so that only derived objects may be created
@@ -133,7 +133,7 @@ protected:
      * @param sched the scheduler that will be used to manage worker threads
      * @param endpoint TCP endpoint used to listen for new connections (see ASIO docs)
      */
-    server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint);
+    server(scheduler& sched, const asio::ip::tcp::endpoint& endpoint);
     
     /**
      * handles a new TCP connection; derived classes SHOULD override this
@@ -153,7 +153,7 @@ protected:
     virtual void after_stopping(void) {}
     
     /// returns an async I/O service used to schedule work
-    inline boost::asio::io_service& get_io_service(void) { return m_active_scheduler.get_io_service(); }
+    inline asio::io_service& get_io_service(void) { return m_active_scheduler.get_io_service(); }
     
     
     /// primary logging interface used by this class
@@ -175,7 +175,7 @@ private:
      * @param accept_error true if an error occurred while accepting connections
      */
     void handle_accept(const tcp::connection_ptr& tcp_conn,
-                      const boost::system::error_code& accept_error);
+                      const asio::error_code& accept_error);
 
     /**
      * handles new connections following an SSL handshake (checks for errors)
@@ -184,7 +184,7 @@ private:
      * @param handshake_error true if an error occurred during the SSL handshake
      */
     void handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
-                            const boost::system::error_code& handshake_error);
+                            const asio::error_code& handshake_error);
     
     /// This will be called by connection::finish() after a server has
     /// finished handling a connection.  If the keep_alive flag is true,
@@ -208,7 +208,7 @@ private:
     scheduler &                             m_active_scheduler;
     
     /// manages async TCP connections
-    boost::asio::ip::tcp::acceptor          m_tcp_acceptor;
+    asio::ip::tcp::acceptor          m_tcp_acceptor;
 
     /// context used for SSL configuration
     connection::ssl_context_type            m_ssl_context;
@@ -223,7 +223,7 @@ private:
     ConnectionPool                          m_conn_pool;
 
     /// tcp endpoint used to listen for new connections
-    boost::asio::ip::tcp::endpoint          m_endpoint;
+    asio::ip::tcp::endpoint          m_endpoint;
 
     /// true if the server uses SSL to encrypt connections
     bool                                    m_ssl_flag;
@@ -237,7 +237,7 @@ private:
 
 
 /// data type for a server pointer
-typedef boost::shared_ptr<server>    server_ptr;
+typedef std::shared_ptr<server>    server_ptr;
 
 
 }   // end namespace tcp

--- a/include/pion/tcp/stream.hpp
+++ b/include/pion/tcp/stream.hpp
@@ -54,7 +54,7 @@ public:
      * @param conn_ptr pointer to the TCP connection to use for reading & writing
      */
     explicit stream_buffer(const tcp::connection_ptr& conn_ptr)
-        : m_conn_ptr(conn_ptr), m_bytes_transferred(0), m_read_buf(m_conn_ptr->get_read_buffer().c_array())
+        : m_conn_ptr(conn_ptr), m_bytes_transferred(0), m_read_buf(m_conn_ptr->get_read_buffer().data())
     {
         setup_buffers();
     }
@@ -68,7 +68,7 @@ public:
     explicit stream_buffer(asio::io_service& io_service,
                              const bool ssl_flag = false)
         : m_conn_ptr(new connection(io_service, ssl_flag)),
-        m_read_buf(m_conn_ptr->get_read_buffer().c_array())
+        m_read_buf(m_conn_ptr->get_read_buffer().data())
     {
         setup_buffers();
     }
@@ -82,7 +82,7 @@ public:
     stream_buffer(asio::io_service& io_service,
                     connection::ssl_context_type& ssl_context)
         : m_conn_ptr(new connection(io_service, ssl_context)),
-        m_read_buf(m_conn_ptr->get_read_buffer().c_array())
+        m_read_buf(m_conn_ptr->get_read_buffer().data())
     {
         setup_buffers();
     }
@@ -298,13 +298,13 @@ private:
     tcp::connection_ptr         m_conn_ptr;
     
     /// condition signaled whenever an asynchronous operation has completed
-    std::mutex                m_async_mutex;
+    std::mutex                  m_async_mutex;
     
     /// condition signaled whenever an asynchronous operation has completed
-    std::condition_variable            m_async_done;
+    std::condition_variable     m_async_done;
     
     /// used to keep track of the result from the last asynchronous operation
-    asio::error_code   m_async_error;
+    asio::error_code            m_async_error;
     
     /// the number of bytes transferred by the last asynchronous operation
     std::size_t                 m_bytes_transferred;

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -10,10 +10,9 @@
 #ifndef __PION_TCP_TIMER_HEADER__
 #define __PION_TCP_TIMER_HEADER__
 
-#include <boost/asio.hpp>
+#include <memory>
+#include <asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
@@ -27,7 +26,7 @@ namespace tcp {     // begin namespace tcp
 /// timer: helper class used to time-out TCP connections
 ///
 class PION_API timer
-    : public boost::enable_shared_from_this<timer>
+    : public std::enable_shared_from_this<timer>
 {
 public:
 
@@ -43,7 +42,7 @@ public:
      *
      * @param seconds number of seconds before the timeout triggers
      */
-    void start(const boost::uint32_t seconds);
+    void start(const uint32_t seconds);
 
     /// cancel the timer (operation completed)
     void cancel(void);
@@ -56,13 +55,13 @@ private:
      *
      * @param ec deadline timer error status code
      */
-    void timer_callback(const boost::system::error_code& ec);
+    void timer_callback(const asio::error_code& ec);
 
     /// pointer to the TCP connection that is being monitored
     tcp::connection_ptr                     m_conn_ptr;
 
     /// deadline timer used to timeout TCP operations
-    boost::asio::deadline_timer             m_timer;
+    asio::deadline_timer             m_timer;
     
     /// mutex used to synchronize the TCP connection timer
     boost::mutex                            m_mutex;
@@ -76,7 +75,7 @@ private:
 
 
 /// shared pointer to a timer object
-typedef boost::shared_ptr<timer>     timer_ptr;
+typedef std::shared_ptr<timer>     timer_ptr;
 
 
 }   // end namespace tcp

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -41,7 +41,7 @@ public:
      *
      * @param seconds number of seconds before the timeout triggers
      */
-    void start(const uint32_t seconds);
+    void start(const std::uint32_t seconds);
 
     /// cancel the timer (operation completed)
     void cancel(void);

--- a/include/pion/tcp/timer.hpp
+++ b/include/pion/tcp/timer.hpp
@@ -11,9 +11,8 @@
 #define __PION_TCP_TIMER_HEADER__
 
 #include <memory>
+#include <mutex>
 #include <asio.hpp>
-#include <boost/bind.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/tcp/connection.hpp>
 
@@ -64,7 +63,7 @@ private:
     asio::deadline_timer             m_timer;
     
     /// mutex used to synchronize the TCP connection timer
-    boost::mutex                            m_mutex;
+    std::mutex                            m_mutex;
 
     /// true if the deadline timer is active
     bool                                    m_timer_active; 

--- a/include/pion/user.hpp
+++ b/include/pion/user.hpp
@@ -16,7 +16,6 @@
 #include <cstring>
 #include <memory>
 #include <boost/noncopyable.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
@@ -27,6 +26,8 @@
         #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     #endif
     #include <openssl/sha.h>
+#include <mutex>
+
 #endif
 
 
@@ -177,7 +178,7 @@ public:
 
     /// returns true if no users are defined
     inline bool empty(void) const {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         return m_users.empty();
     }
 
@@ -192,7 +193,7 @@ public:
     virtual bool add_user(const std::string &username,
         const std::string &password)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i!=m_users.end())
             return false;
@@ -212,7 +213,7 @@ public:
     virtual bool update_user(const std::string &username,
         const std::string &password)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i==m_users.end())
             return false;
@@ -232,7 +233,7 @@ public:
     virtual bool add_user_hash(const std::string &username,
         const std::string &password_hash)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i!=m_users.end())
             return false;
@@ -253,7 +254,7 @@ public:
     virtual bool update_user_hash(const std::string &username,
         const std::string &password_hash)
     {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i==m_users.end())
             return false;
@@ -268,7 +269,7 @@ public:
      * @return false if no user with such username
      */
     virtual bool remove_user(const std::string &username) {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::iterator i = m_users.find(username);
         if (i==m_users.end())
             return false;
@@ -280,7 +281,7 @@ public:
      * Used to locate user object by username
      */
     virtual user_ptr get_user(const std::string &username) {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::const_iterator i = m_users.find(username);
         if (i==m_users.end())
             return user_ptr();
@@ -292,7 +293,7 @@ public:
      * Used to locate user object by username and password
      */
     virtual user_ptr get_user(const std::string& username, const std::string& password) {
-        boost::mutex::scoped_lock lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
         user_map_t::const_iterator i = m_users.find(username);
         if (i==m_users.end() || !i->second->match_password(password))
             return user_ptr();
@@ -308,7 +309,7 @@ protected:
 
 
     /// mutex used to protect access to the user list
-    mutable boost::mutex    m_mutex;
+    mutable std::mutex    m_mutex;
 
     /// user records container
     user_map_t              m_users;

--- a/include/pion/user.hpp
+++ b/include/pion/user.hpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <cstdio>
 #include <cstring>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/noncopyable.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/numeric/conversion/cast.hpp>
@@ -158,7 +158,7 @@ protected:
 };
 
 /// data type for a user  pointer
-typedef boost::shared_ptr<user> user_ptr;
+typedef std::shared_ptr<user> user_ptr;
 
 
 ///
@@ -315,7 +315,7 @@ protected:
 };
 
 /// data type for a user_manager pointer
-typedef boost::shared_ptr<user_manager>  user_manager_ptr;
+typedef std::shared_ptr<user_manager>  user_manager_ptr;
 
 
 }   // end namespace pion

--- a/services/AllowNothingService.cpp
+++ b/services/AllowNothingService.cpp
@@ -21,7 +21,7 @@ void AllowNothingService::operator()(const http::request_ptr& http_request_ptr, 
 {
     static const std::string DENY_HTML = "<html><body>No, you can't.</body></html>";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_METHOD_NOT_ALLOWED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_METHOD_NOT_ALLOWED);
 

--- a/services/CookieService.cpp
+++ b/services/CookieService.cpp
@@ -28,7 +28,7 @@ void CookieService::operator()(const http::request_ptr& http_request_ptr, const 
 
     // Set Content-type for HTML and write the header
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_content_type(http::types::CONTENT_TYPE_HTML);
     writer->write_no_copy(HEADER_HTML);
 

--- a/services/EchoService.cpp
+++ b/services/EchoService.cpp
@@ -46,7 +46,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     
     // Set Content-type to "text/plain" (plain ascii text)
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_content_type(http::types::CONTENT_TYPE_TEXT);
     
     // write request information
@@ -79,7 +79,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);
     std::for_each(http_request_ptr->get_headers().begin(), http_request_ptr->get_headers().end(),
-                  boost::bind(&writeDictionaryTerm, writer, _1));
+                  std::bind(&writeDictionaryTerm, writer, std::placeholders::_1));
     writer->write_no_copy(http::types::STRING_CRLF);
 
     // write query parameters
@@ -87,7 +87,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);
     std::for_each(http_request_ptr->get_queries().begin(), http_request_ptr->get_queries().end(),
-                  boost::bind(&writeDictionaryTerm, writer, _1));
+                  std::bind(&writeDictionaryTerm, writer, std::placeholders::_1));
     writer->write_no_copy(http::types::STRING_CRLF);
     
     // write cookie parameters
@@ -95,7 +95,7 @@ void EchoService::operator()(const http::request_ptr& http_request_ptr, const tc
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);
     std::for_each(http_request_ptr->get_cookies().begin(), http_request_ptr->get_cookies().end(),
-                  boost::bind(&writeDictionaryTerm, writer, _1));
+                  std::bind(&writeDictionaryTerm, writer, std::placeholders::_1));
     writer->write_no_copy(http::types::STRING_CRLF);
     
     // write POST content

--- a/services/EchoService.cpp
+++ b/services/EchoService.cpp
@@ -8,7 +8,7 @@
 //
 
 #include "EchoService.hpp"
-#include <boost/bind.hpp>
+#include <functional>
 #include <pion/algorithm.hpp>
 #include <pion/http/response_writer.hpp>
 #include <pion/user.hpp>

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -8,7 +8,6 @@
 //
 
 #include <asio.hpp>
-#include <boost/bind.hpp>
 #include <boost/assert.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -766,7 +765,7 @@ void DiskFile::update(void)
 void DiskFile::read(void)
 {
     // re-allocate storage buffer for the file's content
-    m_file_content.reset(new char[m_file_size]);
+    m_file_content.reset(new char[m_file_size], [](char* arr) { delete [] arr; });
 
     // open the file for reading
     boost::filesystem::ifstream file_stream;
@@ -881,7 +880,7 @@ void DiskFileSender::send(void)
         // check if the content buffer was initialized yet
         if (! m_content_buf) {
             // allocate memory for the new content buffer
-            m_content_buf.reset(new char[m_file_bytes_to_send]);
+            m_content_buf.reset(new char[m_file_bytes_to_send], [](char* arr) { delete [] arr; });
         }
         file_content_ptr = m_content_buf.get();
 

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -228,7 +228,7 @@ void FileService::operator()(const http::request_ptr& http_request_ptr, const tc
         if (m_cache_setting > 0 || m_scan_setting > 0) {
 
             // search for a matching cache entry
-            boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+            std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
             CacheMap::iterator cache_itr = m_cache_map.find(relative_path);
 
             if (cache_itr == m_cache_map.end()) {
@@ -365,7 +365,7 @@ void FileService::operator()(const http::request_ptr& http_request_ptr, const tc
                     // add new entry to the cache
                     PION_LOG_DEBUG(m_logger, "Adding cache entry for request ("
                                    << get_resource() << "): " << relative_path);
-                    boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+                    std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
                     m_cache_map.insert( std::make_pair(relative_path, response_file) );
                 }
             }
@@ -598,7 +598,7 @@ void FileService::start(void)
         if (m_cache_setting == 0 && m_scan_setting > 1)
             m_cache_setting = 1;
 
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
 
         // add entry for file if one is defined
         if (! m_file.empty()) {
@@ -617,7 +617,7 @@ void FileService::stop(void)
 {
     PION_LOG_DEBUG(m_logger, "Shutting down resource (" << get_resource() << ')');
     // clear cached files (if started again, it will re-scan)
-    boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+    std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
     m_cache_map.clear();
 }
 

--- a/services/FileService.cpp
+++ b/services/FileService.cpp
@@ -34,7 +34,7 @@ const unsigned int          FileService::DEFAULT_CACHE_SETTING = 1;
 const unsigned int          FileService::DEFAULT_SCAN_SETTING = 0;
 const unsigned long         FileService::DEFAULT_MAX_CACHE_SIZE = 0;    /* 0=disabled */
 const unsigned long         FileService::DEFAULT_MAX_CHUNK_SIZE = 0;    /* 0=disabled */
-boost::once_flag            FileService::m_mime_types_init_flag = BOOST_ONCE_INIT;
+std::once_flag              FileService::m_mime_types_init_flag;
 FileService::MIMETypeMap    *FileService::m_mime_types_ptr = NULL;
 
 
@@ -714,7 +714,7 @@ FileService::addCacheEntry(const std::string& relative_path,
 
 std::string FileService::findMIMEType(const std::string& file_name) {
     // initialize m_mime_types if it hasn't been done already
-    boost::call_once(FileService::createMIMETypes, m_mime_types_init_flag);
+    std::call_once(m_mime_types_init_flag, FileService::createMIMETypes);
 
     // determine the file's extension
     std::string extension(file_name.substr(file_name.find_last_of('.') + 1));

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -131,7 +131,7 @@ protected:
 /// DiskFileSender: class used to send files to clients using HTTP responses
 /// 
 class DiskFileSender : 
-    public boost::enable_shared_from_this<DiskFileSender>,
+    public std::enable_shared_from_this<DiskFileSender>,
     private boost::noncopyable
 {
 public:
@@ -143,13 +143,13 @@ public:
      * @param tcp_conn TCP connection used to send the file
      * @param max_chunk_size sets the maximum chunk size (default=0, unlimited)
      */
-    static inline boost::shared_ptr<DiskFileSender>
+    static inline std::shared_ptr<DiskFileSender>
         create(DiskFile& file,
                const pion::http::request_ptr& http_request_ptr,
                const pion::tcp::connection_ptr& tcp_conn,
                unsigned long max_chunk_size = 0) 
     {
-        return boost::shared_ptr<DiskFileSender>(new DiskFileSender(file, http_request_ptr,
+        return std::shared_ptr<DiskFileSender>(new DiskFileSender(file, http_request_ptr,
                                                                     tcp_conn, max_chunk_size));
     }
 
@@ -189,7 +189,7 @@ protected:
      * @param write_error error status from the last write operation
      * @param bytes_written number of bytes sent by the last write operation
      */
-    void handle_write(const boost::system::error_code& write_error,
+    void handle_write(const asio::error_code& write_error,
                      std::size_t bytes_written);
 
 
@@ -226,7 +226,7 @@ private:
 };
 
 /// data type for a DiskFileSender pointer
-typedef boost::shared_ptr<DiskFileSender>       DiskFileSenderPtr;
+typedef std::shared_ptr<DiskFileSender>       DiskFileSenderPtr;
 
 
 ///

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -10,9 +10,7 @@
 #ifndef __PION_FILESERVICE_HEADER__
 #define __PION_FILESERVICE_HEADER__
 
-#include <boost/functional/hash.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/shared_array.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
 #include <pion/hash_map.hpp>
@@ -110,7 +108,7 @@ protected:
     boost::filesystem::path     m_file_path;
 
     /// content of the cached file
-    boost::shared_array<char>   m_file_content;
+    std::shared_ptr<char>       m_file_content;
 
     /// size of the file's content
     std::streamsize             m_file_size;
@@ -208,7 +206,7 @@ private:
     boost::filesystem::ifstream             m_file_stream;
 
     /// buffer used to send file content
-    boost::shared_array<char>               m_content_buf;
+    std::shared_ptr<char>                   m_content_buf;
 
     /**
      * maximum chunk size (in bytes): files larger than this size will be

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/functional/hash.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/thread/once.hpp>
 #include <boost/shared_array.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
@@ -25,6 +24,7 @@
 #include <map>
 #include <mutex>
 #include <memory>
+#include <thread>
 
 namespace pion {        // begin namespace pion
 namespace plugins {     // begin namespace plugins
@@ -336,7 +336,7 @@ private:
     static const unsigned long  DEFAULT_MAX_CHUNK_SIZE;
 
     /// flag used to make sure that createMIMETypes() is called only once
-    static boost::once_flag     m_mime_types_init_flag;
+    static std::once_flag     m_mime_types_init_flag;
 
     /// map of file extensions to MIME types
     static MIMETypeMap *        m_mime_types_ptr;

--- a/services/FileService.hpp
+++ b/services/FileService.hpp
@@ -10,11 +10,9 @@
 #ifndef __PION_FILESERVICE_HEADER__
 #define __PION_FILESERVICE_HEADER__
 
-#include <boost/shared_ptr.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/thread/once.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/shared_array.hpp>
 #include <pion/config.hpp>
 #include <pion/logger.hpp>
@@ -25,7 +23,8 @@
 #include <pion/http/server.hpp>
 #include <string>
 #include <map>
-
+#include <mutex>
+#include <memory>
 
 namespace pion {        // begin namespace pion
 namespace plugins {     // begin namespace plugins
@@ -353,7 +352,7 @@ private:
     CacheMap                    m_cache_map;
 
     /// mutex used to make the file cache thread-safe
-    boost::mutex                m_cache_mutex;
+    std::mutex                m_cache_mutex;
 
     /**
      * cache configuration setting:

--- a/services/HelloService.cpp
+++ b/services/HelloService.cpp
@@ -23,7 +23,7 @@ void HelloService::operator()(const http::request_ptr& http_request_ptr, const t
 {
     static const std::string HELLO_HTML = "<html><body>Hello World!</body></html>";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->write_no_copy(HELLO_HTML);
     writer->write_no_copy(http::types::STRING_CRLF);
     writer->write_no_copy(http::types::STRING_CRLF);

--- a/services/LogService.cpp
+++ b/services/LogService.cpp
@@ -11,10 +11,8 @@
 
 #if defined(PION_USE_LOG4CXX)
     #include <log4cxx/spi/loggingevent.h>
-    #include <boost/lexical_cast.hpp>
 #elif defined(PION_USE_LOG4CPLUS)
     #include <log4cplus/spi/loggingevent.h>
-    #include <boost/lexical_cast.hpp>
 #elif defined(PION_USE_LOG4CPP)
     #include <log4cpp/BasicLayout.hh>
 #endif
@@ -58,7 +56,7 @@ LogServiceAppender::~LogServiceAppender()
 void LogServiceAppender::append(const log4cxx::spi::LoggingEventPtr& event)
 {
     // custom layouts is not supported for log4cxx library
-    std::string formatted_string(boost::lexical_cast<std::string>(event->getTimeStamp()));
+    std::string formatted_string(std::to_string(event->getTimeStamp()));
     formatted_string += ' ';
     formatted_string += event->getLevel()->toString();
     formatted_string += ' ';
@@ -72,7 +70,7 @@ void LogServiceAppender::append(const log4cxx::spi::LoggingEventPtr& event)
 void LogServiceAppender::append(const log4cplus::spi::InternalLoggingEvent& event)
 {
     // custom layouts is not supported for log4cplus library
-    std::string formatted_string(boost::lexical_cast<std::string>(event.getTimestamp().sec()));
+    std::string formatted_string(std::to_string(event.getTimestamp().sec()));
     formatted_string += ' ';
     formatted_string += m_log_level_manager.toString(event.getLogLevel());
     formatted_string += ' ';
@@ -155,7 +153,7 @@ void LogService::operator()(const http::request_ptr& http_request_ptr, const tcp
 {
     // Set Content-type to "text/plain" (plain ascii text)
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                                   boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                                   std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_content_type(http::types::CONTENT_TYPE_TEXT);
     getLogAppender().writeLogEvents(writer);
     writer->send();

--- a/services/LogService.cpp
+++ b/services/LogService.cpp
@@ -90,7 +90,7 @@ void LogServiceAppender::_append(const log4cpp::LoggingEvent& event)
 
 void LogServiceAppender::addLogString(const std::string& log_string)
 {
-    boost::mutex::scoped_lock log_lock(m_log_mutex);
+    std::unique_lock<std::mutex> log_lock(m_log_mutex);
     m_log_events.push_back(log_string);
     ++m_num_events;
     while (m_num_events > m_max_events) {
@@ -102,7 +102,7 @@ void LogServiceAppender::addLogString(const std::string& log_string)
 void LogServiceAppender::writeLogEvents(const pion::http::response_writer_ptr& writer)
 {
 #if defined(PION_USE_LOG4CXX) || defined(PION_USE_LOG4CPLUS) || defined(PION_USE_LOG4CPP)
-    boost::mutex::scoped_lock log_lock(m_log_mutex);
+    std::unique_lock<std::mutex> log_lock(m_log_mutex);
     for (std::list<std::string>::const_iterator i = m_log_events.begin();
          i != m_log_events.end(); ++i)
     {

--- a/services/LogService.hpp
+++ b/services/LogService.hpp
@@ -10,13 +10,13 @@
 #ifndef __PION_LOGSERVICE_HEADER__
 #define __PION_LOGSERVICE_HEADER__
 
-#include <boost/scoped_ptr.hpp>
 #include <pion/logger.hpp>
 #include <pion/http/plugin_service.hpp>
 #include <pion/http/response_writer.hpp>
 #include <string>
 #include <list>
 #include <mutex>
+#include <memory>
 
 #if defined(PION_USE_LOG4CXX)
     #include <log4cxx/appenderskeleton.h>
@@ -109,7 +109,7 @@ private:
         virtual void _append(const log4cpp::LoggingEvent& event);
     private:
         /// the logging layout used to format events
-        boost::scoped_ptr<log4cpp::Layout>      m_layout_ptr;
+        std::unique_ptr<log4cpp::Layout>      m_layout_ptr;
 #endif
 
 };

--- a/services/LogService.hpp
+++ b/services/LogService.hpp
@@ -10,13 +10,13 @@
 #ifndef __PION_LOGSERVICE_HEADER__
 #define __PION_LOGSERVICE_HEADER__
 
-#include <boost/thread/mutex.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <pion/logger.hpp>
 #include <pion/http/plugin_service.hpp>
 #include <pion/http/response_writer.hpp>
 #include <string>
 #include <list>
+#include <mutex>
 
 #if defined(PION_USE_LOG4CXX)
     #include <log4cxx/appenderskeleton.h>

--- a/services/LogService.hpp
+++ b/services/LogService.hpp
@@ -73,7 +73,7 @@ private:
     std::list<std::string>                  m_log_events;
 
     /// mutex to make class thread-safe
-    boost::mutex                            m_log_mutex;
+    std::mutex                            m_log_mutex;
 
 #if defined(PION_USE_LOG4CXX)
     public:

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -13,7 +13,7 @@
     #include <sys/types.h>
     #include <unistd.h>
     #include <sys/types.h>
-    #include <boost/regex.hpp>
+    #include <regex>
     #include <boost/tokenizer.hpp>
     #include <fstream>
 #endif
@@ -24,7 +24,7 @@ namespace pion {    // begin namespace pion
 
 // static members of admin_rights
 
-const boost::int16_t    admin_rights::ADMIN_USER_ID = 0;
+const int16_t         admin_rights::ADMIN_USER_ID = 0;
 std::mutex            admin_rights::m_mutex;
 
 
@@ -118,8 +118,8 @@ long admin_rights::find_system_id(const std::string& name,
     const std::string& file)
 {
     // check if name is the system id
-    const boost::regex just_numbers("\\d+");
-    if (boost::regex_match(name, just_numbers)) {
+    const std::regex just_numbers("\\d+");
+    if (std::regex_match(name, just_numbers)) {
         return std::stol(name);
     }
 
@@ -133,7 +133,7 @@ long admin_rights::find_system_id(const std::string& name,
     typedef boost::tokenizer<boost::char_separator<char> > Tok;
     boost::char_separator<char> sep(":");
     std::string line;
-    boost::int32_t system_id = -1;
+    int32_t system_id = -1;
 
     while (std::getline(system_file, line, '\n')) {
         Tok tokens(line, sep);
@@ -141,7 +141,7 @@ long admin_rights::find_system_id(const std::string& name,
         if (token_it != tokens.end() && *token_it == name) {
             // found line matching name
             if (++token_it != tokens.end() && ++token_it != tokens.end()
-                && boost::regex_match(*token_it, just_numbers))
+                && std::regex_match(*token_it, just_numbers))
             {
                 // found id as third parameter
                 system_id = std::stoi(*token_it);

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -25,7 +25,7 @@ namespace pion {    // begin namespace pion
 // static members of admin_rights
 
 const boost::int16_t    admin_rights::ADMIN_USER_ID = 0;
-boost::mutex            admin_rights::m_mutex;
+std::mutex            admin_rights::m_mutex;
 
 
 // admin_rights member functions

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -24,8 +24,8 @@ namespace pion {    // begin namespace pion
 
 // static members of admin_rights
 
-const int16_t         admin_rights::ADMIN_USER_ID = 0;
-std::mutex            admin_rights::m_mutex;
+const std::int16_t          admin_rights::ADMIN_USER_ID = 0;
+std::mutex                  admin_rights::m_mutex;
 
 
 // admin_rights member functions
@@ -133,7 +133,7 @@ long admin_rights::find_system_id(const std::string& name,
     typedef boost::tokenizer<boost::char_separator<char> > Tok;
     boost::char_separator<char> sep(":");
     std::string line;
-    int32_t system_id = -1;
+    std::int32_t system_id = -1;
 
     while (std::getline(system_file, line, '\n')) {
         Tok tokens(line, sep);

--- a/src/admin_rights.cpp
+++ b/src/admin_rights.cpp
@@ -15,7 +15,6 @@
     #include <sys/types.h>
     #include <boost/regex.hpp>
     #include <boost/tokenizer.hpp>
-    #include <boost/lexical_cast.hpp>
     #include <fstream>
 #endif
 
@@ -121,7 +120,7 @@ long admin_rights::find_system_id(const std::string& name,
     // check if name is the system id
     const boost::regex just_numbers("\\d+");
     if (boost::regex_match(name, just_numbers)) {
-        return boost::lexical_cast<boost::int32_t>(name);
+        return std::stol(name);
     }
 
     // open system file
@@ -145,7 +144,7 @@ long admin_rights::find_system_id(const std::string& name,
                 && boost::regex_match(*token_it, just_numbers))
             {
                 // found id as third parameter
-                system_id = boost::lexical_cast<boost::int32_t>(*token_it);
+                system_id = std::stoi(*token_it);
             }
             break;
         }

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -316,7 +316,7 @@ void algorithm::float_from_bytes(long double& value, const unsigned char *ptr, s
     
     // build exponent value from bitstream
     unsigned char mask = 0x80;
-    int16_t exponent = 0;
+    std::int16_t exponent = 0;
     for (size_t n = 0; n < num_exp_bits; ++n) {
         SHIFT_BITMASK(ptr, mask);
         exponent *= 2;
@@ -336,7 +336,7 @@ void algorithm::float_from_bytes(long double& value, const unsigned char *ptr, s
     }
     
     // calculate final value
-    exponent -= (int16_t)(::pow((long double)2, (int)(num_exp_bits - 1)) - 1);
+    exponent -= (std::int16_t)(::pow((long double)2, (int)(num_exp_bits - 1)) - 1);
     value = value_sign * significand * ::pow((long double)2, exponent);
 }
 
@@ -353,7 +353,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     }
     
     // break down numbers >= 1.0 by incrementing the exponent & dividing by 2
-    int16_t exponent = 0;
+    std::int16_t exponent = 0;
     while (value >= 1) {
         value /= 2;
         ++exponent;
@@ -372,7 +372,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     
     // serialize fractional value < 1.0
     bool got_exponent = false;
-    uint16_t num_bits = 0;
+    ustd::int16_t num_bits = 0;
     while (value && num_bits < num_fraction_bits) {
         value *= 2;
         if (got_exponent) {
@@ -393,7 +393,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     
     // normalize exponent.
     // note: we should have a zero exponent if value == 0
-    int32_t high_bit = (int32_t)(::pow((long double)2, (int)(num_exp_bits - 1)));
+    std::int32_t high_bit = (std::int32_t)(::pow((long double)2, (int)(num_exp_bits - 1)));
     if (got_exponent)
         exponent += (high_bit - 1);
     else

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -316,7 +316,7 @@ void algorithm::float_from_bytes(long double& value, const unsigned char *ptr, s
     
     // build exponent value from bitstream
     unsigned char mask = 0x80;
-    boost::int16_t exponent = 0;
+    int16_t exponent = 0;
     for (size_t n = 0; n < num_exp_bits; ++n) {
         SHIFT_BITMASK(ptr, mask);
         exponent *= 2;
@@ -336,7 +336,7 @@ void algorithm::float_from_bytes(long double& value, const unsigned char *ptr, s
     }
     
     // calculate final value
-    exponent -= (boost::int16_t)(::pow((long double)2, (int)(num_exp_bits - 1)) - 1);
+    exponent -= (int16_t)(::pow((long double)2, (int)(num_exp_bits - 1)) - 1);
     value = value_sign * significand * ::pow((long double)2, exponent);
 }
 
@@ -353,7 +353,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     }
     
     // break down numbers >= 1.0 by incrementing the exponent & dividing by 2
-    boost::int16_t exponent = 0;
+    int16_t exponent = 0;
     while (value >= 1) {
         value /= 2;
         ++exponent;
@@ -372,7 +372,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     
     // serialize fractional value < 1.0
     bool got_exponent = false;
-    boost::uint16_t num_bits = 0;
+    uint16_t num_bits = 0;
     while (value && num_bits < num_fraction_bits) {
         value *= 2;
         if (got_exponent) {
@@ -393,7 +393,7 @@ void algorithm::float_to_bytes(long double value, unsigned char *buf, size_t num
     
     // normalize exponent.
     // note: we should have a zero exponent if value == 0
-    boost::int32_t high_bit = (boost::int32_t)(::pow((long double)2, (int)(num_exp_bits - 1)));
+    int32_t high_bit = (int32_t)(::pow((long double)2, (int)(num_exp_bits - 1)));
     if (got_exponent)
         exponent += (high_bit - 1);
     else

--- a/src/http_auth.cpp
+++ b/src/http_auth.cpp
@@ -20,7 +20,7 @@ namespace http {    // begin namespace http
 
 void auth::add_restrict(const std::string& resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(http::server::strip_trailing_slash(resource));
     m_restrict_list.insert(clean_resource);
     PION_LOG_INFO(m_logger, "Set authentication restrictions for HTTP resource: " << clean_resource);
@@ -28,7 +28,7 @@ void auth::add_restrict(const std::string& resource)
 
 void auth::add_permit(const std::string& resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(http::server::strip_trailing_slash(resource));
     m_white_list.insert(clean_resource);
     PION_LOG_INFO(m_logger, "Set authentication permission for HTTP resource: " << clean_resource);
@@ -43,7 +43,7 @@ bool auth::need_authentication(const http::request_ptr& http_request_ptr) const
     // strip off trailing slash if the request has one
     std::string resource(http::server::strip_trailing_slash(http_request_ptr->get_resource()));
     
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     
     // just return false if restricted list is empty
     if (m_restrict_list.empty())

--- a/src/http_basic_auth.cpp
+++ b/src/http_basic_auth.cpp
@@ -41,7 +41,7 @@ bool basic_auth::handle_request(const http::request_ptr& http_request_ptr, const
     boost::posix_time::ptime time_now(boost::posix_time::second_clock::universal_time());
     if (time_now > m_cache_cleanup_time + boost::posix_time::seconds(CACHE_EXPIRATION)) {
         // expire cache
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
         user_cache_type::iterator i;
         user_cache_type::iterator next=m_user_cache.begin();
         while (next!=m_user_cache.end()) {
@@ -61,7 +61,7 @@ bool basic_auth::handle_request(const http::request_ptr& http_request_ptr, const
         std::string credentials;
         if (parse_authorization(authorization, credentials)) {
             // to do - use fast cache to match with active credentials
-            boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+            std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
             user_cache_type::iterator user_cache_ptr=m_user_cache.find(credentials);
             if (user_cache_ptr!=m_user_cache.end()) {
                 // we found the credentials in our cache...

--- a/src/http_basic_auth.cpp
+++ b/src/http_basic_auth.cpp
@@ -145,7 +145,7 @@ void basic_auth::handle_unauthorized(const http::request_ptr& http_request_ptr,
         "<BODY><H1>401 Unauthorized.</H1></BODY>"
         "</HTML> ";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                                   boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                                   std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_UNAUTHORIZED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_UNAUTHORIZED);
     writer->get_response().add_header("WWW-Authenticate", "Basic realm=\"" + m_realm + "\"");

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -40,7 +40,7 @@ cookie_auth::cookie_auth(user_manager_ptr userManager,
     set_logger(PION_GET_LOGGER("pion.http.cookie_auth"));
 
     // Seed random number generator with current time as time_t int value, cast to the required type.
-    // (Note that boost::mt19937::result_type is uint32_t, and casting to an unsigned n-bit integer is
+    // (Note that boost::mt19937::result_type is ustd::int32_t, and casting to an unsigned n-bit integer is
     // defined by the standard to keep the lower n bits.  Since ::time() returns seconds since Jan 1, 1970, 
     // it will be a long time before we lose any entropy here, even if time_t is a 64-bit int.)
     m_random_gen.seed(static_cast<std::mt19937::result_type>(::time(NULL)));

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -73,7 +73,7 @@ bool cookie_auth::handle_request(const http::request_ptr& http_request_ptr, cons
     const std::string auth_cookie(http_request_ptr->get_cookie(AUTH_COOKIE_NAME));
     if (! auth_cookie.empty()) {
         // check if this cookie is in user cache
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
         user_cache_type::iterator user_cache_itr=m_user_cache.find(auth_cookie);
         if (user_cache_itr != m_user_cache.end()) {
             // we find those credential in our cache...
@@ -139,14 +139,14 @@ bool cookie_auth::process_login(const http::request_ptr& http_request_ptr, const
 
         // add new session to cache
         boost::posix_time::ptime time_now(boost::posix_time::second_clock::universal_time());
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
         m_user_cache.insert(std::make_pair(new_cookie,std::make_pair(time_now,user)));
     } else {
         // process logout sequence
         // if auth cookie presented - clean cache out
         const std::string auth_cookie(http_request_ptr->get_cookie(AUTH_COOKIE_NAME));
         if (! auth_cookie.empty()) {
-            boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+            std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
             user_cache_type::iterator user_cache_itr=m_user_cache.find(auth_cookie);
             if (user_cache_itr!=m_user_cache.end()) {
                 m_user_cache.erase(user_cache_itr);
@@ -262,7 +262,7 @@ void cookie_auth::expire_cache(const boost::posix_time::ptime &time_now)
 {
     if (time_now > m_cache_cleanup_time + boost::posix_time::seconds(CACHE_EXPIRATION)) {
         // expire cache
-        boost::mutex::scoped_lock cache_lock(m_cache_mutex);
+        std::unique_lock<std::mutex> cache_lock(m_cache_mutex);
         user_cache_type::iterator i;
         user_cache_type::iterator next=m_user_cache.begin();
         while (next!=m_user_cache.end()) {

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -33,7 +33,7 @@ cookie_auth::cookie_auth(user_manager_ptr userManager,
                                const std::string& logout,
                                const std::string& redirect)
     : http::auth(userManager), m_login(login), m_logout(logout), m_redirect(redirect),
-    m_random_gen(), m_random_range(0, 255), m_random_die(m_random_gen, m_random_range),
+    m_random_gen(), m_random_range(0, 255), m_random_die(std::bind(m_random_range, m_random_gen)),
     m_cache_cleanup_time(boost::posix_time::second_clock::universal_time())
 {
     // set logger for this class
@@ -43,7 +43,7 @@ cookie_auth::cookie_auth(user_manager_ptr userManager,
     // (Note that boost::mt19937::result_type is uint32_t, and casting to an unsigned n-bit integer is
     // defined by the standard to keep the lower n bits.  Since ::time() returns seconds since Jan 1, 1970, 
     // it will be a long time before we lose any entropy here, even if time_t is a 64-bit int.)
-    m_random_gen.seed(static_cast<boost::mt19937::result_type>(::time(NULL)));
+    m_random_gen.seed(static_cast<std::mt19937::result_type>(::time(NULL)));
 
     // generate some random numbers to increase entropy of the rng
     for (unsigned int n = 0; n < 100; ++n)

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -189,7 +189,7 @@ void cookie_auth::handle_unauthorized(const http::request_ptr& http_request_ptr,
         "<BODY><H1>401 Unauthorized.</H1></BODY>"
         "</HTML> ";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-    boost::bind(&tcp::connection::finish, tcp_conn)));
+    std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_UNAUTHORIZED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_UNAUTHORIZED);
     writer->write_no_copy(CONTENT);
@@ -215,7 +215,7 @@ void cookie_auth::handle_redirection(const http::request_ptr& http_request_ptr,
         "<BODY><H1>302 Found.</H1></BODY>"
         "</HTML> ";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-        boost::bind(&tcp::connection::finish, tcp_conn)));
+        std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_FOUND);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_FOUND);
     writer->get_response().add_header(http::types::HEADER_LOCATION, redirection_url);
@@ -242,7 +242,7 @@ void cookie_auth::handle_ok(const http::request_ptr& http_request_ptr,
 {
     // send 204 (No Content) response
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-        boost::bind(&tcp::connection::finish, tcp_conn)));
+        std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_NO_CONTENT);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_NO_CONTENT);
     // Note: use empty pass "" while setting cookies to workaround IE/FF difference

--- a/src/http_cookie_auth.cpp
+++ b/src/http_cookie_auth.cpp
@@ -40,7 +40,7 @@ cookie_auth::cookie_auth(user_manager_ptr userManager,
     set_logger(PION_GET_LOGGER("pion.http.cookie_auth"));
 
     // Seed random number generator with current time as time_t int value, cast to the required type.
-    // (Note that boost::mt19937::result_type is boost::uint32_t, and casting to an unsigned n-bit integer is
+    // (Note that boost::mt19937::result_type is uint32_t, and casting to an unsigned n-bit integer is
     // defined by the standard to keep the lower n bits.  Since ::time() returns seconds since Jan 1, 1970, 
     // it will be a long time before we lose any entropy here, even if time_t is a 64-bit int.)
     m_random_gen.seed(static_cast<boost::mt19937::result_type>(::time(NULL)));

--- a/src/http_message.cpp
+++ b/src/http_message.cpp
@@ -9,7 +9,7 @@
 
 #include <iostream>
 #include <algorithm>
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <boost/assert.hpp>
 #include <boost/regex.hpp>
 #include <boost/logic/tribool.hpp>
@@ -31,7 +31,7 @@ const boost::regex  message::REGEX_ICASE_CHUNKED(".*chunked.*", boost::regex::ic
 // message member functions
 
 std::size_t message::send(tcp::connection& tcp_conn,
-                          boost::system::error_code& ec, bool headers_only)
+                          asio::error_code& ec, bool headers_only)
 {
     // initialize write buffers for send operation using HTTP headers
     write_buffers_t write_buffers;
@@ -39,14 +39,14 @@ std::size_t message::send(tcp::connection& tcp_conn,
 
     // append payload content to write buffers (if there is any)
     if (!headers_only && get_content_length() > 0 && get_content() != NULL)
-        write_buffers.push_back(boost::asio::buffer(get_content(), get_content_length()));
+        write_buffers.push_back(asio::buffer(get_content(), get_content_length()));
 
     // send the message and return the result
     return tcp_conn.write(write_buffers, ec);
 }
 
 std::size_t message::receive(tcp::connection& tcp_conn,
-                             boost::system::error_code& ec,
+                             asio::error_code& ec,
                              parser& http_parser)
 {
     std::size_t last_bytes_read = 0;
@@ -83,7 +83,7 @@ std::size_t message::receive(tcp::connection& tcp_conn,
             if (http_parser.check_premature_eof(*this)) {
                 // premature EOF encountered
                 if (! ec)
-                    ec = make_error_code(boost::system::errc::io_error);
+                    ec = asio::error::eof;//make_error_code(boost::system::errc::io_error);
                 return http_parser.get_total_bytes_read();
             } else {
                 // EOF reached when content length unknown
@@ -141,7 +141,7 @@ std::size_t message::receive(tcp::connection& tcp_conn,
 }
 
 std::size_t message::receive(tcp::connection& tcp_conn,
-                             boost::system::error_code& ec,
+                             asio::error_code& ec,
                              bool headers_only,
                              std::size_t max_content_length)
 {
@@ -152,7 +152,7 @@ std::size_t message::receive(tcp::connection& tcp_conn,
 }
 
 std::size_t message::write(std::ostream& out,
-    boost::system::error_code& ec, bool headers_only)
+    asio::error_code& ec, bool headers_only)
 {
     // reset error_code
     ec.clear();
@@ -163,16 +163,16 @@ std::size_t message::write(std::ostream& out,
 
     // append payload content to write buffers (if there is any)
     if (!headers_only && get_content_length() > 0 && get_content() != NULL)
-        write_buffers.push_back(boost::asio::buffer(get_content(), get_content_length()));
+        write_buffers.push_back(asio::buffer(get_content(), get_content_length()));
 
     // write message to the output stream
     std::size_t bytes_out = 0;
     for (write_buffers_t::const_iterator i=write_buffers.begin(); i!=write_buffers.end(); ++i) {
-        const char *ptr = boost::asio::buffer_cast<const char*>(*i);
-        size_t len = boost::asio::buffer_size(*i);
+        const char *ptr = asio::buffer_cast<const char*>(*i);
+        size_t len = asio::buffer_size(*i);
         out.write(ptr, len);
         if (!out) {
-          ec = make_error_code(boost::system::errc::io_error);
+//          ec = make_error_code(boost::system::errc::io_error);
           break;
         }
         bytes_out += len;
@@ -182,7 +182,7 @@ std::size_t message::write(std::ostream& out,
 }
 
 std::size_t message::read(std::istream& in,
-                          boost::system::error_code& ec,
+                          asio::error_code& ec,
                           parser& http_parser)
 {
     // make sure that we start out with an empty message & clear error_code
@@ -195,7 +195,7 @@ std::size_t message::read(std::istream& in,
     while (in) {
         in.read(&c, 1);
         if ( ! in ) {
-            ec = make_error_code(boost::system::errc::io_error);
+//            ec = make_error_code(boost::system::errc::io_error);
             break;
         }
         http_parser.set_read_buffer(&c, 1);
@@ -207,7 +207,7 @@ std::size_t message::read(std::istream& in,
         if (http_parser.check_premature_eof(*this)) {
             // premature EOF encountered
             if (! ec)
-                ec = make_error_code(boost::system::errc::io_error);
+                ec = asio::error::eof;//make_error_code(boost::system::errc::io_error);
         } else {
             // EOF reached when content length unknown
             // assume it is the correct end of content
@@ -221,7 +221,7 @@ std::size_t message::read(std::istream& in,
 }
 
 std::size_t message::read(std::istream& in,
-                          boost::system::error_code& ec,
+                          asio::error_code& ec,
                           bool headers_only,
                           std::size_t max_content_length)
 {

--- a/src/http_message.cpp
+++ b/src/http_message.cpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <asio.hpp>
 #include <boost/assert.hpp>
-#include <boost/regex.hpp>
 #include <boost/logic/tribool.hpp>
 #include <pion/http/message.hpp>
 #include <pion/http/request.hpp>
@@ -25,7 +24,7 @@ namespace http {    // begin namespace http
 
 // static members of message
 
-const boost::regex  message::REGEX_ICASE_CHUNKED(".*chunked.*", boost::regex::icase);
+const std::regex  message::REGEX_ICASE_CHUNKED("[^]*chunked[^]*", std::regex::icase);
 
 
 // message member functions

--- a/src/http_message.cpp
+++ b/src/http_message.cpp
@@ -195,7 +195,7 @@ std::size_t message::read(std::istream& in,
     while (in) {
         in.read(&c, 1);
         if ( ! in ) {
-//            ec = make_error_code(boost::system::errc::io_error);
+            ec = make_error_code(asio::error::eof);
             break;
         }
         http_parser.set_read_buffer(&c, 1);
@@ -207,7 +207,7 @@ std::size_t message::read(std::istream& in,
         if (http_parser.check_premature_eof(*this)) {
             // premature EOF encountered
             if (! ec)
-                ec = asio::error::eof;//make_error_code(boost::system::errc::io_error);
+                ec = make_error_code(asio::error::eof);//make_error_code(boost::system::errc::io_error);
         } else {
             // EOF reached when content length unknown
             // assume it is the correct end of content

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -25,16 +25,16 @@ namespace http {    // begin namespace http
 
 // static members of parser
 
-const uint32_t   parser::STATUS_MESSAGE_MAX = 1024;  // 1 KB
-const uint32_t   parser::METHOD_MAX = 1024;  // 1 KB
-const uint32_t   parser::RESOURCE_MAX = 256 * 1024;  // 256 KB
-const uint32_t   parser::QUERY_STRING_MAX = 1024 * 1024; // 1 MB
-const uint32_t   parser::HEADER_NAME_MAX = 1024; // 1 KB
-const uint32_t   parser::HEADER_VALUE_MAX = 1024 * 1024; // 1 MB
-const uint32_t   parser::QUERY_NAME_MAX = 1024;  // 1 KB
-const uint32_t   parser::QUERY_VALUE_MAX = 1024 * 1024;  // 1 MB
-const uint32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
-const uint32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
+const ustd::int32_t   parser::STATUS_MESSAGE_MAX = 1024;  // 1 KB
+const ustd::int32_t   parser::METHOD_MAX = 1024;  // 1 KB
+const ustd::int32_t   parser::RESOURCE_MAX = 256 * 1024;  // 256 KB
+const ustd::int32_t   parser::QUERY_STRING_MAX = 1024 * 1024; // 1 MB
+const ustd::int32_t   parser::HEADER_NAME_MAX = 1024; // 1 KB
+const ustd::int32_t   parser::HEADER_VALUE_MAX = 1024 * 1024; // 1 MB
+const ustd::int32_t   parser::QUERY_NAME_MAX = 1024;  // 1 KB
+const ustd::int32_t   parser::QUERY_VALUE_MAX = 1024 * 1024;  // 1 MB
+const ustd::int32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
+const ustd::int32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
 const std::size_t       parser::DEFAULT_CONTENT_MAX = 1024 * 1024;  // 1 MB
 parser::error_category_t * parser::m_error_category_ptr = NULL;
 std::once_flag            parser::m_instance_flag;
@@ -827,7 +827,7 @@ boost::tribool parser::finish_header_parsing(http::message& http_msg,
 }
     
 bool parser::parse_uri(const std::string& uri, std::string& proto, 
-                      std::string& host, uint16_t& port,
+                      std::string& host, ustd::int16_t& port,
                       std::string& path, std::string& query)
 {
     size_t proto_end = uri.find("://");

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -9,7 +9,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <boost/regex.hpp>
 #include <boost/assert.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/algorithm/string.hpp>
@@ -38,7 +37,7 @@ const boost::uint32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
 const boost::uint32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
 const std::size_t       parser::DEFAULT_CONTENT_MAX = 1024 * 1024;  // 1 MB
 parser::error_category_t * parser::m_error_category_ptr = NULL;
-boost::once_flag            parser::m_instance_flag = BOOST_ONCE_INIT;
+std::once_flag            parser::m_instance_flag;
 
 
 // parser member functions
@@ -1574,29 +1573,29 @@ void parser::create_error_category(void)
 bool parser::parse_forwarded_for(const std::string& header, std::string& public_ip)
 {
     // static regex's used to check for ipv4 address
-    static const boost::regex IPV4_ADDR_RX("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}");
+    static const std::regex IPV4_ADDR_RX("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}");
 
     /// static regex used to check for private/local networks:
     /// 10.*
     /// 127.*
     /// 192.168.*
     /// 172.16-31.*
-    static const boost::regex PRIVATE_NET_RX("(10\\.[0-9]{1,3}|127\\.[0-9]{1,3}|192\\.168|172\\.1[6-9]|172\\.2[0-9]|172\\.3[0-1])\\.[0-9]{1,3}\\.[0-9]{1,3}");
+    static const std::regex PRIVATE_NET_RX("(10\\.[0-9]{1,3}|127\\.[0-9]{1,3}|192\\.168|172\\.1[6-9]|172\\.2[0-9]|172\\.3[0-1])\\.[0-9]{1,3}\\.[0-9]{1,3}");
 
     // sanity check
     if (header.empty())
         return false;
 
     // local variables re-used by while loop
-    boost::match_results<std::string::const_iterator> m;
+    std::match_results<std::string::const_iterator> m;
     std::string::const_iterator start_it = header.begin();
 
     // search for next ip address within the header
-    while (boost::regex_search(start_it, header.end(), m, IPV4_ADDR_RX)) {
+    while (std::regex_search(start_it, header.end(), m, IPV4_ADDR_RX)) {
         // get ip that matched
         std::string ip_str(m[0].first, m[0].second);
         // check if public network ip address
-        if (! boost::regex_match(ip_str, PRIVATE_NET_RX) ) {
+        if (! std::regex_match(ip_str, PRIVATE_NET_RX) ) {
             // match found!
             public_ip = ip_str;
             return true;

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -25,16 +25,16 @@ namespace http {    // begin namespace http
 
 // static members of parser
 
-const boost::uint32_t   parser::STATUS_MESSAGE_MAX = 1024;  // 1 KB
-const boost::uint32_t   parser::METHOD_MAX = 1024;  // 1 KB
-const boost::uint32_t   parser::RESOURCE_MAX = 256 * 1024;  // 256 KB
-const boost::uint32_t   parser::QUERY_STRING_MAX = 1024 * 1024; // 1 MB
-const boost::uint32_t   parser::HEADER_NAME_MAX = 1024; // 1 KB
-const boost::uint32_t   parser::HEADER_VALUE_MAX = 1024 * 1024; // 1 MB
-const boost::uint32_t   parser::QUERY_NAME_MAX = 1024;  // 1 KB
-const boost::uint32_t   parser::QUERY_VALUE_MAX = 1024 * 1024;  // 1 MB
-const boost::uint32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
-const boost::uint32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
+const uint32_t   parser::STATUS_MESSAGE_MAX = 1024;  // 1 KB
+const uint32_t   parser::METHOD_MAX = 1024;  // 1 KB
+const uint32_t   parser::RESOURCE_MAX = 256 * 1024;  // 256 KB
+const uint32_t   parser::QUERY_STRING_MAX = 1024 * 1024; // 1 MB
+const uint32_t   parser::HEADER_NAME_MAX = 1024; // 1 KB
+const uint32_t   parser::HEADER_VALUE_MAX = 1024 * 1024; // 1 MB
+const uint32_t   parser::QUERY_NAME_MAX = 1024;  // 1 KB
+const uint32_t   parser::QUERY_VALUE_MAX = 1024 * 1024;  // 1 MB
+const uint32_t   parser::COOKIE_NAME_MAX = 1024; // 1 KB
+const uint32_t   parser::COOKIE_VALUE_MAX = 1024 * 1024; // 1 MB
 const std::size_t       parser::DEFAULT_CONTENT_MAX = 1024 * 1024;  // 1 MB
 parser::error_category_t * parser::m_error_category_ptr = NULL;
 std::once_flag            parser::m_instance_flag;
@@ -827,7 +827,7 @@ boost::tribool parser::finish_header_parsing(http::message& http_msg,
 }
     
 bool parser::parse_uri(const std::string& uri, std::string& proto, 
-                      std::string& host, boost::uint16_t& port,
+                      std::string& host, uint16_t& port,
                       std::string& path, std::string& query)
 {
     size_t proto_end = uri.find("://");

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -44,7 +44,7 @@ boost::once_flag            parser::m_instance_flag = BOOST_ONCE_INIT;
 // parser member functions
 
 boost::tribool parser::parse(http::message& http_msg,
-    boost::system::error_code& ec)
+    asio::error_code& ec)
 {
     BOOST_ASSERT(! eof() );
 
@@ -123,7 +123,7 @@ boost::tribool parser::parse(http::message& http_msg,
 }
 
 boost::tribool parser::parse_missing_data(http::message& http_msg,
-    std::size_t len, boost::system::error_code& ec)
+    std::size_t len, asio::error_code& ec)
 {
     static const char MISSING_DATA_CHAR = 'X';
     boost::tribool rc = boost::indeterminate;
@@ -237,7 +237,7 @@ boost::tribool parser::parse_missing_data(http::message& http_msg,
 }
 
 boost::tribool parser::parse_headers(http::message& http_msg,
-    boost::system::error_code& ec)
+    asio::error_code& ec)
 {
     //
     // note that boost::tribool may have one of THREE states:
@@ -741,7 +741,7 @@ void parser::update_message_with_header_data(http::message& http_msg) const
 }
 
 boost::tribool parser::finish_header_parsing(http::message& http_msg,
-    boost::system::error_code& ec)
+    asio::error_code& ec)
 {
     boost::tribool rc = boost::indeterminate;
 
@@ -865,8 +865,8 @@ bool parser::parse_uri(const std::string& uri, std::string& proto,
     // parse the port, if it's not empty
     if(port_pos != std::string::npos) {
         try {
-            port = boost::lexical_cast<int>(t.substr(port_pos+1));
-        } catch (boost::bad_lexical_cast &) {
+            port = std::stoi(t.substr(port_pos+1));
+        } catch (std::invalid_argument &) {
             return false;
         }
     } else if (proto == "http" || proto == "HTTP") {
@@ -1256,7 +1256,7 @@ bool parser::parse_cookie_header(ihash_multimap& dict,
 }
 
 boost::tribool parser::parse_chunks(http::message::chunk_cache_t& chunks,
-    boost::system::error_code& ec)
+    asio::error_code& ec)
 {
     //
     // note that boost::tribool may have one of THREE states:
@@ -1422,7 +1422,7 @@ boost::tribool parser::parse_chunks(http::message::chunk_cache_t& chunks,
 }
 
 boost::tribool parser::consume_content(http::message& http_msg,
-    boost::system::error_code& /* ec */)
+    asio::error_code& /* ec */)
 {
     size_t content_bytes_to_read;
     size_t content_bytes_available = bytes_available();

--- a/src/http_plugin_server.cpp
+++ b/src/http_plugin_server.cpp
@@ -28,7 +28,7 @@ void plugin_server::add_service(const std::string& resource, http::plugin_servic
     const std::string clean_resource(strip_trailing_slash(resource));
     service_ptr->set_resource(clean_resource);
     m_services.add(clean_resource, service_ptr);
-    http::server::add_resource(clean_resource, boost::ref(*service_ptr));
+    http::server::add_resource(clean_resource, std::ref(*service_ptr));
     PION_LOG_INFO(m_logger, "Loaded static web service for resource (" << clean_resource << ")");
 }
 
@@ -37,7 +37,7 @@ void plugin_server::load_service(const std::string& resource, const std::string&
     const std::string clean_resource(strip_trailing_slash(resource));
     http::plugin_service *service_ptr;
     service_ptr = m_services.load(clean_resource, service_name);
-    http::server::add_resource(clean_resource, boost::ref(*service_ptr));
+    http::server::add_resource(clean_resource, std::ref(*service_ptr));
     service_ptr->set_resource(clean_resource);
     PION_LOG_INFO(m_logger, "Loaded web service plug-in for resource (" << clean_resource << "): " << service_name);
 }
@@ -46,7 +46,7 @@ void plugin_server::set_service_option(const std::string& resource,
                                  const std::string& name, const std::string& value)
 {
     const std::string clean_resource(strip_trailing_slash(resource));
-    m_services.run(clean_resource, boost::bind(&http::plugin_service::set_option, _1, name, value));
+    m_services.run(clean_resource, std::bind(&http::plugin_service::set_option, std::placeholders::_1, name, value));
     PION_LOG_INFO(m_logger, "Set web service option for resource ("
                   << resource << "): " << name << '=' << value);
 }

--- a/src/http_reader.cpp
+++ b/src/http_reader.cpp
@@ -7,7 +7,7 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <boost/logic/tribool.hpp>
 #include <pion/http/reader.hpp>
 #include <pion/http/request.hpp>
@@ -38,8 +38,7 @@ void reader::receive(void)
     }
 }
 
-void reader::consume_bytes(const boost::system::error_code& read_error,
-                              std::size_t bytes_read)
+void reader::consume_bytes(const asio::error_code& read_error, std::size_t bytes_read)
 {
     // cancel read timer if operation didn't time-out
     if (m_timer_ptr) {
@@ -73,7 +72,7 @@ void reader::consume_bytes(void)
     // true: finished successfully parsing the message
     // indeterminate: parsed bytes, but the message is not yet finished
     //
-    boost::system::error_code ec;
+    asio::error_code ec;
     boost::tribool result = parse(get_message(), ec);
     
     if (gcount() > 0) {
@@ -131,21 +130,21 @@ void reader::read_bytes_with_timeout(void)
     read_bytes();
 }
 
-void reader::handle_read_error(const boost::system::error_code& read_error)
+void reader::handle_read_error(const asio::error_code& read_error)
 {
     // close the connection, forcing the client to establish a new one
     m_tcp_conn->set_lifecycle(tcp::connection::LIFECYCLE_CLOSE);   // make sure it will get closed
 
     // check if this is just a message with unknown content length
     if (! check_premature_eof(get_message())) {
-        boost::system::error_code ec;   // clear error code
+        asio::error_code ec;   // clear error code
         finished_reading(ec);
         return;
     }
     
     // only log errors if the parsing has already begun
     if (get_total_bytes_read() > 0) {
-        if (read_error == boost::asio::error::operation_aborted) {
+        if (read_error == asio::error::operation_aborted) {
             // if the operation was aborted, the acceptor was stopped,
             // which means another thread is shutting-down the server
             PION_LOG_INFO(m_logger, "HTTP " << (is_parsing_request() ? "request" : "response")

--- a/src/http_reader.cpp
+++ b/src/http_reader.cpp
@@ -19,7 +19,7 @@ namespace http {    // begin namespace http
 
 // reader static members
     
-const boost::uint32_t       reader::DEFAULT_READ_TIMEOUT = 10;
+const uint32_t       reader::DEFAULT_READ_TIMEOUT = 10;
 
 
 // reader member functions

--- a/src/http_reader.cpp
+++ b/src/http_reader.cpp
@@ -19,7 +19,7 @@ namespace http {    // begin namespace http
 
 // reader static members
     
-const uint32_t       reader::DEFAULT_READ_TIMEOUT = 10;
+const ustd::int32_t       reader::DEFAULT_READ_TIMEOUT = 10;
 
 
 // reader member functions

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -131,7 +131,7 @@ bool server::find_request_handler(const std::string& resource,
                                     request_handler_t& request_handler) const
 {
     // first make sure that HTTP resources are registered
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     if (m_resources.empty())
         return false;
     
@@ -156,7 +156,7 @@ bool server::find_request_handler(const std::string& resource,
 void server::add_resource(const std::string& resource,
                              request_handler_t request_handler)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(strip_trailing_slash(resource));
     m_resources.insert(std::make_pair(clean_resource, request_handler));
     PION_LOG_INFO(m_logger, "Added request handler for HTTP resource: " << clean_resource);
@@ -164,7 +164,7 @@ void server::add_resource(const std::string& resource,
 
 void server::remove_resource(const std::string& resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     const std::string clean_resource(strip_trailing_slash(resource));
     m_resources.erase(clean_resource);
     PION_LOG_INFO(m_logger, "Removed request handler for HTTP resource: " << clean_resource);
@@ -173,7 +173,7 @@ void server::remove_resource(const std::string& resource)
 void server::add_redirect(const std::string& requested_resource,
                              const std::string& new_resource)
 {
-    boost::mutex::scoped_lock resource_lock(m_resource_mutex);
+    std::unique_lock<std::mutex> resource_lock(m_resource_mutex);
     const std::string clean_requested_resource(strip_trailing_slash(requested_resource));
     const std::string clean_new_resource(strip_trailing_slash(new_resource));
     m_redirects.insert(std::make_pair(clean_requested_resource, clean_new_resource));

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -29,14 +29,14 @@ const unsigned int          server::MAX_REDIRECTS = 10;
 void server::handle_connection(const tcp::connection_ptr& tcp_conn)
 {
     request_reader_ptr my_reader_ptr;
-    my_reader_ptr = request_reader::create(tcp_conn, boost::bind(&server::handle_request,
-                                           this, _1, _2, _3));
+    my_reader_ptr = request_reader::create(tcp_conn, std::bind(&server::handle_request,
+                                           this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     my_reader_ptr->set_max_content_length(m_max_content_length);
     my_reader_ptr->receive();
 }
 
 void server::handle_request(const http::request_ptr& http_request_ptr,
-    const tcp::connection_ptr& tcp_conn, const boost::system::error_code& ec)
+    const tcp::connection_ptr& tcp_conn, const asio::error_code& ec)
 {
     if (ec || ! http_request_ptr->is_valid()) {
         tcp_conn->set_lifecycle(tcp::connection::LIFECYCLE_CLOSE); // make sure it will get closed
@@ -45,11 +45,7 @@ void server::handle_request(const http::request_ptr& http_request_ptr,
             PION_LOG_INFO(m_logger, "Invalid HTTP request (" << ec.message() << ")");
             m_bad_request_handler(http_request_ptr, tcp_conn);
         } else {
-            static const boost::system::error_condition
-                    ERRCOND_CANCELED(boost::system::errc::operation_canceled, boost::system::system_category()),
-                    ERRCOND_EOF(boost::asio::error::eof, boost::asio::error::misc_category);
-
-            if (ec == ERRCOND_CANCELED || ec == ERRCOND_EOF) {
+            if (ec == asio::error::operation_aborted || ec == asio::error::eof) {
                 // don't spam the log with common (non-)errors that happen during normal operation
                 PION_LOG_DEBUG(m_logger, "Lost connection on port " << get_port() << " (" << ec.message() << ")");
             } else {
@@ -195,7 +191,7 @@ void server::handle_bad_request(const http::request_ptr& http_request_ptr,
         "<p>Your browser sent a request that this server could not understand.</p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_BAD_REQUEST);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_BAD_REQUEST);
     writer->write_no_copy(BAD_REQUEST_HTML);
@@ -215,7 +211,7 @@ void server::handle_not_found_request(const http::request_ptr& http_request_ptr,
         " was not found on this server.</p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_NOT_FOUND);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_NOT_FOUND);
     writer->write_no_copy(NOT_FOUND_HTML_START);
@@ -238,7 +234,7 @@ void server::handle_server_error(const http::request_ptr& http_request_ptr,
         "</strong></p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_SERVER_ERROR);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_SERVER_ERROR);
     writer->write_no_copy(SERVER_ERROR_HTML_START);
@@ -263,7 +259,7 @@ void server::handle_forbidden_request(const http::request_ptr& http_request_ptr,
         "</strong></p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_FORBIDDEN);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_FORBIDDEN);
     writer->write_no_copy(FORBIDDEN_HTML_START);
@@ -288,7 +284,7 @@ void server::handle_method_not_allowed(const http::request_ptr& http_request_ptr
         " is not allowed on this server.</p>\n"
         "</body></html>\n";
     http::response_writer_ptr writer(http::response_writer::create(tcp_conn, *http_request_ptr,
-                                                            boost::bind(&tcp::connection::finish, tcp_conn)));
+                                                            std::bind(&tcp::connection::finish, tcp_conn)));
     writer->get_response().set_status_code(http::types::RESPONSE_CODE_METHOD_NOT_ALLOWED);
     writer->get_response().set_status_message(http::types::RESPONSE_MESSAGE_METHOD_NOT_ALLOWED);
     if (! allowed_methods.empty())

--- a/src/http_types.cpp
+++ b/src/http_types.cpp
@@ -7,12 +7,11 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/thread/mutex.hpp>
 #include <pion/http/types.hpp>
 #include <pion/algorithm.hpp>
 #include <cstdio>
 #include <ctime>
-
+#include <mutex>
 
 namespace pion {    // begin namespace pion
 namespace http {    // begin namespace http
@@ -97,12 +96,12 @@ const unsigned int  types::RESPONSE_CODE_CONTINUE = 100;
 std::string types::get_date_string(const time_t t)
 {
     // use mutex since time functions are normally not thread-safe
-    static boost::mutex time_mutex;
+    static std::mutex time_mutex;
     static const char *TIME_FORMAT = "%a, %d %b %Y %H:%M:%S GMT";
     static const unsigned int TIME_BUF_SIZE = 100;
     char time_buf[TIME_BUF_SIZE+1];
 
-    boost::mutex::scoped_lock time_lock(time_mutex);
+    std::unique_lock<std::mutex> time_lock(time_mutex);
     if (strftime(time_buf, TIME_BUF_SIZE, TIME_FORMAT, gmtime(&t)) == 0)
         time_buf[0] = '\0'; // failed; resulting buffer is indeterminate
     time_lock.unlock();

--- a/src/http_types.cpp
+++ b/src/http_types.cpp
@@ -7,7 +7,6 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/lexical_cast.hpp>
 #include <boost/thread/mutex.hpp>
 #include <pion/http/types.hpp>
 #include <pion/algorithm.hpp>
@@ -141,7 +140,7 @@ std::string types::make_set_cookie_header(const std::string& name,
     }
     if (has_max_age) {
         set_cookie_header += "; Max-Age=";
-        set_cookie_header += boost::lexical_cast<std::string>(max_age);
+        set_cookie_header += std::to_string(max_age);
     }
     return set_cookie_header;
 }

--- a/src/http_writer.cpp
+++ b/src/http_writer.cpp
@@ -7,7 +7,7 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <pion/http/writer.hpp>
 #include <pion/http/message.hpp>
 
@@ -45,15 +45,15 @@ void writer::prepare_write_buffers(http::message::write_buffers_t& write_buffers
             // add chunk length as a string at the back of the text cache
             m_text_cache.push_back(cast_buf);
             // append length of chunk to write_buffers
-            write_buffers.push_back(boost::asio::buffer(m_text_cache.back()));
+            write_buffers.push_back(asio::buffer(m_text_cache.back()));
             // append an extra CRLF for chunk formatting
-            write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
+            write_buffers.push_back(asio::buffer(http::types::STRING_CRLF));
             
             // append response content buffers
             write_buffers.insert(write_buffers.end(), m_content_buffers.begin(),
                                  m_content_buffers.end());
             // append an extra CRLF for chunk formatting
-            write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
+            write_buffers.push_back(asio::buffer(http::types::STRING_CRLF));
         } else {
             // append response content buffers
             write_buffers.insert(write_buffers.end(), m_content_buffers.begin(),
@@ -66,10 +66,10 @@ void writer::prepare_write_buffers(http::message::write_buffers_t& write_buffers
         // add chunk length as a string at the back of the text cache
         m_text_cache.push_back("0");
         // append length of chunk to write_buffers
-        write_buffers.push_back(boost::asio::buffer(m_text_cache.back()));
+        write_buffers.push_back(asio::buffer(m_text_cache.back()));
         // append an extra CRLF for chunk formatting
-        write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
-        write_buffers.push_back(boost::asio::buffer(http::types::STRING_CRLF));
+        write_buffers.push_back(asio::buffer(http::types::STRING_CRLF));
+        write_buffers.push_back(asio::buffer(http::types::STRING_CRLF));
     }
 }
 

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -9,10 +9,10 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/config.hpp>
 #include <pion/error.hpp>
 #include <pion/plugin.hpp>
+#include <mutex>
 
 #ifdef PION_WIN32
     #include <windows.h>
@@ -33,7 +33,7 @@ const std::string           plugin::PION_PLUGIN_DESTROY("pion_destroy_");
     const std::string           plugin::PION_PLUGIN_EXTENSION(".so");
 #endif
 const std::string           plugin::PION_CONFIG_EXTENSION(".conf");
-boost::once_flag            plugin::m_instance_flag = BOOST_ONCE_INIT;
+std::once_flag            plugin::m_instance_flag;
 plugin::config_type    *plugin::m_config_ptr = NULL;
 
     

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -66,7 +66,7 @@ void plugin::add_plugin_directory(const std::string& dir)
     if (! boost::filesystem::exists(plugin_path) )
         BOOST_THROW_EXCEPTION( error::directory_not_found() << error::errinfo_dir_name(dir) );
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
 # if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
     cfg.m_plugin_dirs.push_back(plugin_path.string());
 #else
@@ -78,7 +78,7 @@ void plugin::add_plugin_directory(const std::string& dir)
 void plugin::reset_plugin_directories(void)
 {
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
     cfg.m_plugin_dirs.clear();
 }
 
@@ -87,7 +87,7 @@ void plugin::open(const std::string& plugin_name)
     // check first if name matches an existing plugin name
     {
         config_type& cfg = get_plugin_config();
-        boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+        std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
         map_type::iterator itr = cfg.m_plugin_map.find(plugin_name);
         if (itr != cfg.m_plugin_map.end()) {
             release_data();  // make sure we're not already pointing to something
@@ -115,7 +115,7 @@ void plugin::open_file(const std::string& plugin_file)
     
     // check to see if we already have a matching shared library
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
     map_type::iterator itr = cfg.m_plugin_map.find(plugin_data.m_plugin_name);
     if (itr == cfg.m_plugin_map.end()) {
         // no plug-ins found with the same name
@@ -140,7 +140,7 @@ void plugin::release_data(void)
 {
     if (m_plugin_data != NULL) {
         config_type& cfg = get_plugin_config();
-        boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+        std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
         // double-check after locking mutex
         if (m_plugin_data != NULL && --m_plugin_data->m_references == 0) {
             // no more references to the plug-in library
@@ -169,7 +169,7 @@ void plugin::grab_data(const plugin& p)
 {
     release_data();  // make sure we're not already pointing to something
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
     m_plugin_data = const_cast<data_type*>(p.m_plugin_data);
     if (m_plugin_data != NULL) {
         ++ m_plugin_data->m_references;
@@ -185,7 +185,7 @@ bool plugin::find_file(std::string& path_to_file, const std::string& name,
 
     // nope, check search paths
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
     for (std::vector<std::string>::iterator i = cfg.m_plugin_dirs.begin();
          i != cfg.m_plugin_dirs.end(); ++i)
     {
@@ -310,7 +310,7 @@ void plugin::get_all_plugin_names(std::vector<std::string>& plugin_names)
     // Iterate through all the Plugin directories.
     std::vector<std::string>::iterator it;
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
     for (it = cfg.m_plugin_dirs.begin(); it != cfg.m_plugin_dirs.end(); ++it) {
         // Find all shared libraries in the directory and add them to the list of Plugin names.
         boost::filesystem::directory_iterator end;
@@ -397,7 +397,7 @@ void plugin::add_static_entry_point(const std::string& plugin_name,
 {
     // check for duplicate
     config_type& cfg = get_plugin_config();
-    boost::mutex::scoped_lock plugin_lock(cfg.m_plugin_mutex);
+    std::unique_lock<std::mutex> plugin_lock(cfg.m_plugin_mutex);
     map_type::iterator itr = cfg.m_plugin_map.find(plugin_name);
     if (itr == cfg.m_plugin_map.end()) {
         // no plug-ins found with the same name

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -34,7 +34,7 @@ process::config_type *process::m_config_ptr = NULL;
 void process::shutdown(void)
 {
     config_type& cfg = get_config();
-    boost::mutex::scoped_lock shutdown_lock(cfg.shutdown_mutex);
+    std::unique_lock<std::mutex> shutdown_lock(cfg.shutdown_mutex);
     if (! cfg.shutdown_now) {
         cfg.shutdown_now = true;
         cfg.shutdown_cond.notify_all();
@@ -44,7 +44,7 @@ void process::shutdown(void)
 void process::wait_for_shutdown(void)
 {
     config_type& cfg = get_config();
-    boost::mutex::scoped_lock shutdown_lock(cfg.shutdown_mutex);
+    std::unique_lock<std::mutex> shutdown_lock(cfg.shutdown_mutex);
     while (! cfg.shutdown_now)
         cfg.shutdown_cond.wait(shutdown_lock);
 }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -25,7 +25,7 @@ namespace pion {    // begin namespace pion
     
 // static members of process
     
-boost::once_flag                process::m_instance_flag = BOOST_ONCE_INIT;
+std::once_flag                process::m_instance_flag;
 process::config_type *process::m_config_ptr = NULL;
 
     

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -134,7 +134,7 @@ void single_service_scheduler::startup(void)
         keep_running(m_service, m_timer);
         
         // start multiple threads to handle async tasks
-        for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
+        for (uint32_t n = 0; n < m_num_threads; ++n) {
             std::shared_ptr<std::thread> new_thread(new std::thread( std::bind(&scheduler::process_service_work,
                                                                                        this, std::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
@@ -166,7 +166,7 @@ void one_to_one_scheduler::startup(void)
         }
         
         // start multiple threads to handle async tasks
-        for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
+        for (uint32_t n = 0; n < m_num_threads; ++n) {
             std::shared_ptr<std::thread> new_thread(new std::thread( std::bind(&scheduler::process_service_work,
                                                                                        this, std::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -16,10 +16,10 @@ namespace pion {    // begin namespace pion
 
 // static members of scheduler
     
-const boost::uint32_t   scheduler::DEFAULT_NUM_THREADS = 8;
-const boost::uint32_t   scheduler::NSEC_IN_SECOND = 1000000000; // (10^9)
-const boost::uint32_t   scheduler::MICROSEC_IN_SECOND = 1000000;    // (10^6)
-const boost::uint32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
+const uint32_t   scheduler::DEFAULT_NUM_THREADS = 8;
+const uint32_t   scheduler::NSEC_IN_SECOND = 1000000000; // (10^9)
+const uint32_t   scheduler::MICROSEC_IN_SECOND = 1000000;    // (10^6)
+const uint32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
 
 
 // scheduler member functions
@@ -27,7 +27,7 @@ const boost::uint32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
 void scheduler::shutdown(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock scheduler_lock(m_mutex);
+    std::unique_lock<std::mutex> scheduler_lock(m_mutex);
     
     if (m_is_running) {
         
@@ -67,7 +67,7 @@ void scheduler::shutdown(void)
 
 void scheduler::join(void)
 {
-    boost::mutex::scoped_lock scheduler_lock(m_mutex);
+    std::unique_lock<std::mutex> scheduler_lock(m_mutex);
     while (m_is_running) {
         // sleep until scheduler_has_stopped condition is signaled
         m_scheduler_has_stopped.wait(scheduler_lock);
@@ -88,21 +88,21 @@ void scheduler::keep_running(asio::io_service& my_service,
 void scheduler::add_active_user(void)
 {
     if (!m_is_running) startup();
-    boost::mutex::scoped_lock scheduler_lock(m_mutex);
+    std::unique_lock<std::mutex> scheduler_lock(m_mutex);
     ++m_active_users;
 }
 
 void scheduler::remove_active_user(void)
 {
-    boost::mutex::scoped_lock scheduler_lock(m_mutex);
+    std::unique_lock<std::mutex> scheduler_lock(m_mutex);
     if (--m_active_users == 0)
         m_no_more_active_users.notify_all();
 }
 
-boost::system_time scheduler::get_wakeup_time(boost::uint32_t sleep_sec,
-    boost::uint32_t sleep_nsec)
+std::chrono::system_clock::time_point scheduler::get_wakeup_time(uint32_t sleep_sec,
+    uint32_t sleep_nsec)
 {
-    return boost::get_system_time() + boost::posix_time::seconds(sleep_sec) + boost::posix_time::microseconds(sleep_nsec / 1000);
+    return std::chrono::system_clock::now() + std::chrono::seconds(sleep_sec) + std::chrono::microseconds(sleep_nsec / 1000);
 }
                      
 void scheduler::process_service_work(asio::io_service& service) {
@@ -123,7 +123,7 @@ void scheduler::process_service_work(asio::io_service& service) {
 void single_service_scheduler::startup(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock scheduler_lock(m_mutex);
+    std::unique_lock<std::mutex> scheduler_lock(m_mutex);
     
     if (! m_is_running) {
         PION_LOG_INFO(m_logger, "Starting thread scheduler");
@@ -148,7 +148,7 @@ void single_service_scheduler::startup(void)
 void one_to_one_scheduler::startup(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock scheduler_lock(m_mutex);
+    std::unique_lock<std::mutex> scheduler_lock(m_mutex);
     
     if (! m_is_running) {
         PION_LOG_INFO(m_logger, "Starting thread scheduler");

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -81,7 +81,7 @@ void scheduler::keep_running(asio::io_service& my_service,
         // schedule this again to make sure the service doesn't complete
         my_timer.expires_from_now(boost::posix_time::seconds(KEEP_RUNNING_TIMER_SECONDS));
         my_timer.async_wait(std::bind(&scheduler::keep_running, this,
-                                        boost::ref(my_service), boost::ref(my_timer)));
+                                        std::ref(my_service), std::ref(my_timer)));
     }
 }
 
@@ -135,8 +135,8 @@ void single_service_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
-            std::shared_ptr<boost::thread> new_thread(new boost::thread( std::bind(&scheduler::process_service_work,
-                                                                                       this, boost::ref(m_service)) ));
+            std::shared_ptr<std::thread> new_thread(new std::thread( std::bind(&scheduler::process_service_work,
+                                                                                       this, std::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
         }
     }
@@ -167,8 +167,8 @@ void one_to_one_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
-            std::shared_ptr<boost::thread> new_thread(new boost::thread( std::bind(&scheduler::process_service_work,
-                                                                                       this, boost::ref(m_service_pool[n]->first)) ));
+            std::shared_ptr<std::thread> new_thread(new std::thread( std::bind(&scheduler::process_service_work,
+                                                                                       this, std::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);
         }
     }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -74,13 +74,13 @@ void scheduler::join(void)
     }
 }
     
-void scheduler::keep_running(boost::asio::io_service& my_service,
-                                boost::asio::deadline_timer& my_timer)
+void scheduler::keep_running(asio::io_service& my_service,
+                                asio::deadline_timer& my_timer)
 {
     if (m_is_running) {
         // schedule this again to make sure the service doesn't complete
         my_timer.expires_from_now(boost::posix_time::seconds(KEEP_RUNNING_TIMER_SECONDS));
-        my_timer.async_wait(boost::bind(&scheduler::keep_running, this,
+        my_timer.async_wait(std::bind(&scheduler::keep_running, this,
                                         boost::ref(my_service), boost::ref(my_timer)));
     }
 }
@@ -105,7 +105,7 @@ boost::system_time scheduler::get_wakeup_time(boost::uint32_t sleep_sec,
     return boost::get_system_time() + boost::posix_time::seconds(sleep_sec) + boost::posix_time::microseconds(sleep_nsec / 1000);
 }
                      
-void scheduler::process_service_work(boost::asio::io_service& service) {
+void scheduler::process_service_work(asio::io_service& service) {
     while (m_is_running) {
         try {
             service.run();
@@ -135,7 +135,7 @@ void single_service_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
-            boost::shared_ptr<boost::thread> new_thread(new boost::thread( boost::bind(&scheduler::process_service_work,
+            std::shared_ptr<boost::thread> new_thread(new boost::thread( std::bind(&scheduler::process_service_work,
                                                                                        this, boost::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
         }
@@ -156,7 +156,7 @@ void one_to_one_scheduler::startup(void)
         
         // make sure there are enough services initialized
         while (m_service_pool.size() < m_num_threads) {
-            boost::shared_ptr<service_pair_type>  service_ptr(new service_pair_type());
+            std::shared_ptr<service_pair_type>  service_ptr(new service_pair_type());
             m_service_pool.push_back(service_ptr);
         }
 
@@ -167,7 +167,7 @@ void one_to_one_scheduler::startup(void)
         
         // start multiple threads to handle async tasks
         for (boost::uint32_t n = 0; n < m_num_threads; ++n) {
-            boost::shared_ptr<boost::thread> new_thread(new boost::thread( boost::bind(&scheduler::process_service_work,
+            std::shared_ptr<boost::thread> new_thread(new boost::thread( std::bind(&scheduler::process_service_work,
                                                                                        this, boost::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);
         }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -16,10 +16,10 @@ namespace pion {    // begin namespace pion
 
 // static members of scheduler
     
-const uint32_t   scheduler::DEFAULT_NUM_THREADS = 8;
-const uint32_t   scheduler::NSEC_IN_SECOND = 1000000000; // (10^9)
-const uint32_t   scheduler::MICROSEC_IN_SECOND = 1000000;    // (10^6)
-const uint32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
+const ustd::int32_t   scheduler::DEFAULT_NUM_THREADS = 8;
+const ustd::int32_t   scheduler::NSEC_IN_SECOND = 1000000000; // (10^9)
+const ustd::int32_t   scheduler::MICROSEC_IN_SECOND = 1000000;    // (10^6)
+const ustd::int32_t   scheduler::KEEP_RUNNING_TIMER_SECONDS = 5;
 
 
 // scheduler member functions
@@ -99,8 +99,8 @@ void scheduler::remove_active_user(void)
         m_no_more_active_users.notify_all();
 }
 
-std::chrono::system_clock::time_point scheduler::get_wakeup_time(uint32_t sleep_sec,
-    uint32_t sleep_nsec)
+std::chrono::system_clock::time_point scheduler::get_wakeup_time(ustd::int32_t sleep_sec,
+    ustd::int32_t sleep_nsec)
 {
     return std::chrono::system_clock::now() + std::chrono::seconds(sleep_sec) + std::chrono::microseconds(sleep_nsec / 1000);
 }
@@ -134,7 +134,7 @@ void single_service_scheduler::startup(void)
         keep_running(m_service, m_timer);
         
         // start multiple threads to handle async tasks
-        for (uint32_t n = 0; n < m_num_threads; ++n) {
+        for (ustd::int32_t n = 0; n < m_num_threads; ++n) {
             std::shared_ptr<std::thread> new_thread(new std::thread( std::bind(&scheduler::process_service_work,
                                                                                        this, std::ref(m_service)) ));
             m_thread_pool.push_back(new_thread);
@@ -166,7 +166,7 @@ void one_to_one_scheduler::startup(void)
         }
         
         // start multiple threads to handle async tasks
-        for (uint32_t n = 0; n < m_num_threads; ++n) {
+        for (ustd::int32_t n = 0; n < m_num_threads; ++n) {
             std::shared_ptr<std::thread> new_thread(new std::thread( std::bind(&scheduler::process_service_work,
                                                                                        this, std::ref(m_service_pool[n]->first)) ));
             m_thread_pool.push_back(new_thread);

--- a/src/spdy_decompressor.cpp
+++ b/src/spdy_decompressor.cpp
@@ -87,9 +87,9 @@ decompressor::~decompressor()
 }
 
 char* decompressor::decompress(const char *compressed_data_ptr,
-                               boost::uint32_t stream_id,
+                               uint32_t stream_id,
                                const spdy_control_frame_info& frame,
-                               boost::uint32_t header_block_length)
+                               uint32_t header_block_length)
 {
     /// Get our decompressor.
     z_streamp decomp = NULL;
@@ -113,7 +113,7 @@ char* decompressor::decompress(const char *compressed_data_ptr,
     BOOST_ASSERT(decomp);
     
     // Decompress the data
-    boost::uint32_t uncomp_length = 0;
+    uint32_t uncomp_length = 0;
     
     // Catch decompression failures.
     if (!spdy_decompress_header(compressed_data_ptr, decomp,
@@ -130,10 +130,10 @@ char* decompressor::decompress(const char *compressed_data_ptr,
 
 bool decompressor::spdy_decompress_header(const char *compressed_data_ptr,
                                           z_streamp decomp,
-                                          boost::uint32_t length,
-                                          boost::uint32_t& uncomp_length) {
+                                          uint32_t length,
+                                          uint32_t& uncomp_length) {
     int retcode;
-    const boost::uint8_t *hptr = (boost::uint8_t *)compressed_data_ptr;
+    const uint8_t *hptr = (uint8_t *)compressed_data_ptr;
     
     decomp->next_in = (Bytef *)hptr;
     decomp->avail_in = length;

--- a/src/spdy_decompressor.cpp
+++ b/src/spdy_decompressor.cpp
@@ -87,9 +87,9 @@ decompressor::~decompressor()
 }
 
 char* decompressor::decompress(const char *compressed_data_ptr,
-                               uint32_t stream_id,
+                               ustd::int32_t stream_id,
                                const spdy_control_frame_info& frame,
-                               uint32_t header_block_length)
+                               ustd::int32_t header_block_length)
 {
     /// Get our decompressor.
     z_streamp decomp = NULL;
@@ -113,7 +113,7 @@ char* decompressor::decompress(const char *compressed_data_ptr,
     BOOST_ASSERT(decomp);
     
     // Decompress the data
-    uint32_t uncomp_length = 0;
+    ustd::int32_t uncomp_length = 0;
     
     // Catch decompression failures.
     if (!spdy_decompress_header(compressed_data_ptr, decomp,
@@ -130,10 +130,10 @@ char* decompressor::decompress(const char *compressed_data_ptr,
 
 bool decompressor::spdy_decompress_header(const char *compressed_data_ptr,
                                           z_streamp decomp,
-                                          uint32_t length,
-                                          uint32_t& uncomp_length) {
+                                          ustd::int32_t length,
+                                          ustd::int32_t& uncomp_length) {
     int retcode;
-    const uint8_t *hptr = (uint8_t *)compressed_data_ptr;
+    const ustd::int8_t *hptr = (ustd::int8_t *)compressed_data_ptr;
     
     decomp->next_in = (Bytef *)hptr;
     decomp->avail_in = length;

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -20,7 +20,7 @@ namespace pion {    // begin namespace pion
 namespace spdy {    // begin namespace spdy
 
 /// RST stream status string from code, return NULL for unknown status code
-static char const* rst_stream_status(boost::uint32_t rst_stream_status_code)
+static char const* rst_stream_status(uint32_t rst_stream_status_code)
 {
     switch (rst_stream_status_code)
     {
@@ -57,8 +57,8 @@ boost::tribool parser::parse(http_protocol_info& http_info,
                              asio::error_code& ec,
                              const decompressor_ptr& decompressor,
                              const char *packet_ptr,
-                             boost::uint32_t& length_packet,
-                             boost::uint32_t current_stream_count)
+                             uint32_t& length_packet,
+                             uint32_t current_stream_count)
 {
     // initialize read position
     set_read_ptr(packet_ptr);
@@ -72,9 +72,9 @@ bool parser::is_spdy_control_frame(const char *ptr)
     // Parse further for higher accuracy
     
     // Get the control bit
-    boost::uint8_t control_bit;
-    boost::uint16_t version, type;
-    boost::uint16_t byte_value = algorithm::to_uint16(ptr);
+    uint8_t control_bit;
+    uint16_t version, type;
+    uint16_t byte_value = algorithm::to_uint16(ptr);
     control_bit = byte_value >> (sizeof(short) * CHAR_BIT - 1);
 
     if (!control_bit) return false;
@@ -82,7 +82,7 @@ bool parser::is_spdy_control_frame(const char *ptr)
     // Control bit is set; This is a control frame
     
     // Get the version number
-    boost::uint16_t two_bytes = algorithm::to_uint16(ptr);
+    uint16_t two_bytes = algorithm::to_uint16(ptr);
     version = two_bytes & 0x7FFF;
     
     if(version < 1 || version > 3){
@@ -118,7 +118,7 @@ spdy_frame_type parser::get_spdy_frame_type(const char *ptr)
      */
     
     spdy_frame_type spdy_frame;
-    boost::uint8_t first_byte = *((unsigned char *)ptr);
+    uint8_t first_byte = *((unsigned char *)ptr);
     if(first_byte == 0x80){
         spdy_frame = spdy_control_frame;
     }else if(first_byte == 0x0){
@@ -129,27 +129,27 @@ spdy_frame_type parser::get_spdy_frame_type(const char *ptr)
     return spdy_frame;
 }
     
-boost::uint32_t parser::get_control_frame_stream_id(const char *ptr)
+uint32_t parser::get_control_frame_stream_id(const char *ptr)
 {
     // The stream ID for control frames is at a 8 bit offser from start
     ptr += 8;
 
-    boost::uint32_t four_bytes = algorithm::to_uint32(ptr);
+    uint32_t four_bytes = algorithm::to_uint32(ptr);
     return four_bytes & 0x7FFFFFFF;
 }
     
 boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
                                         const decompressor_ptr& decompressor,
                                         http_protocol_info& http_info,
-                                        boost::uint32_t& length_packet,
-                                        boost::uint32_t current_stream_count)
+                                        uint32_t& length_packet,
+                                        uint32_t current_stream_count)
 {
     boost::tribool rc = true;
     
     // Verify that this is a spdy frame
     
     BOOST_ASSERT(m_read_ptr);
-    boost::uint8_t first_byte = (boost::uint8_t)*m_read_ptr;
+    uint8_t first_byte = (uint8_t)*m_read_ptr;
     if (first_byte != 0x80 && first_byte != 0x0) {
         // This is not a SPDY frame, throw an error
         PION_LOG_ERROR(m_logger, "Invalid SPDY Frame");
@@ -157,9 +157,9 @@ boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
         return false;
     }
     
-    boost::uint8_t              control_bit;
+    uint8_t              control_bit;
     spdy_control_frame_info     frame;
-    boost::uint32_t             stream_id = 0;
+    uint32_t             stream_id = 0;
     
     ec.clear();
 
@@ -173,7 +173,7 @@ boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
     
     BOOST_ASSERT(stream_id != 0);
     
-    control_bit = (boost::uint8_t)frame.control_bit;
+    control_bit = (uint8_t)frame.control_bit;
     
     // There is a possibility that there are more than one SPDY frames in one TCP frame
     if(length_packet > frame.length){
@@ -262,13 +262,13 @@ void parser::create_error_category(void)
 
 bool parser::populate_frame(asio::error_code& ec,
                             spdy_control_frame_info& frame,
-                            boost::uint32_t& length_packet,
-                            boost::uint32_t& stream_id,
+                            uint32_t& length_packet,
+                            uint32_t& stream_id,
                             http_protocol_info& http_info)
 {
     // Get the control bit
-    boost::uint8_t control_bit;
-    boost::uint16_t byte_value = algorithm::to_uint16(m_read_ptr);
+    uint8_t control_bit;
+    uint16_t byte_value = algorithm::to_uint16(m_read_ptr);
     control_bit = byte_value >> (sizeof(short) * CHAR_BIT - 1);
     
     frame.control_bit = (control_bit != 0);
@@ -278,7 +278,7 @@ bool parser::populate_frame(asio::error_code& ec,
         // Control bit is set; This is a control frame
         
         // Get the version number
-        boost::uint16_t two_bytes = algorithm::to_uint16(m_read_ptr);
+        uint16_t two_bytes = algorithm::to_uint16(m_read_ptr);
         frame.version = two_bytes & 0x7FFF;
         
         // Increment the read pointer
@@ -304,7 +304,7 @@ bool parser::populate_frame(asio::error_code& ec,
         frame.type = SPDY_DATA;
         frame.version = 0; /* Version doesn't apply to DATA. */
         // Get the stream id
-        boost::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+        uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
         stream_id = four_bytes & 0x7FFFFFFF;
         
         http_info.stream_id = stream_id;
@@ -321,12 +321,12 @@ bool parser::populate_frame(asio::error_code& ec,
     http_info.data_offset +=2;
     
     // Get the flags
-    frame.flags = (boost::uint8_t)*m_read_ptr;
+    frame.flags = (uint8_t)*m_read_ptr;
     
     // Increment the read pointer
     
     // Get the length
-    boost::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+    uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
     frame.length = four_bytes & 0xFFFFFF;
     
     // Increment the read pointer
@@ -348,14 +348,14 @@ void parser::parse_header_payload(asio::error_code &ec,
                                   const decompressor_ptr& decompressor,
                                   const spdy_control_frame_info& frame,
                                   http_protocol_info& http_info,
-                                  boost::uint32_t /* current_stream_count */)
+                                  uint32_t /* current_stream_count */)
 {
-    boost::uint32_t stream_id = 0;
-    boost::uint32_t header_block_length = frame.length;
+    uint32_t stream_id = 0;
+    uint32_t header_block_length = frame.length;
     
     // Get the 31 bit stream id
     
-    boost::uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+    uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
     stream_id = four_bytes & 0x7FFFFFFF;
     
     m_read_ptr += 4;
@@ -416,37 +416,37 @@ void parser::parse_header_payload(asio::error_code &ec,
     // and it is 32 bit in SPDYv3
     
     // TBD : Add support for SPDYv3
-    boost::uint16_t num_name_val_pairs = algorithm::to_uint16(m_uncompressed_ptr);
+    uint16_t num_name_val_pairs = algorithm::to_uint16(m_uncompressed_ptr);
     
     m_uncompressed_ptr += 2;
     
     std::string content_type = "";
     std::string content_encoding = "";
     
-    for(boost::uint16_t count = 0; count < num_name_val_pairs; ++count){
+    for(uint16_t count = 0; count < num_name_val_pairs; ++count){
         
         
         // Get the length of the name
-        boost::uint16_t length_name = algorithm::to_uint16(m_uncompressed_ptr);
+        uint16_t length_name = algorithm::to_uint16(m_uncompressed_ptr);
         std::string name = "";
         
         m_uncompressed_ptr += 2;
         
         {
-            for(boost::uint16_t count = 0; count < length_name; ++count){
+            for(uint16_t count = 0; count < length_name; ++count){
                 name.push_back(*(m_uncompressed_ptr+count));
             }
             m_uncompressed_ptr += length_name;
         }
         
         // Get the length of the value
-        boost::uint16_t length_value = algorithm::to_uint16(m_uncompressed_ptr);
+        uint16_t length_value = algorithm::to_uint16(m_uncompressed_ptr);
         std::string value = "";
         
         m_uncompressed_ptr += 2;
         
         {
-            for(boost::uint16_t count = 0; count < length_value; ++count){
+            for(uint16_t count = 0; count < length_value; ++count){
                 value.push_back(*(m_uncompressed_ptr+count));
             }
             m_uncompressed_ptr += length_value;
@@ -459,7 +459,7 @@ void parser::parse_header_payload(asio::error_code &ec,
 
 void parser::parse_spdy_data(asio::error_code& /* ec */,
                              const spdy_control_frame_info& frame,
-                             boost::uint32_t /* stream_id */,
+                             uint32_t /* stream_id */,
                              http_protocol_info& http_info)
 {
     // This marks the finish flag
@@ -471,7 +471,7 @@ void parser::parse_spdy_data(asio::error_code& /* ec */,
 void parser::parse_spdy_rst_stream(asio::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
-    boost::uint32_t status_code = 0;
+    uint32_t status_code = 0;
     
     // First complete the check for size and flag
     // The flag for RST frame should be 0, The length should be 8
@@ -503,7 +503,7 @@ void parser::parse_spdy_ping_frame(asio::error_code& /* ec */,
         return;
     }
   
-    boost::uint32_t ping_id = 0;
+    uint32_t ping_id = 0;
     
     // Get the 32 bit ping id
     
@@ -530,7 +530,7 @@ void parser::parse_spdy_goaway_frame(asio::error_code &ec,
         return;
     }
     
-    boost::uint32_t status_code = 0;
+    uint32_t status_code = 0;
     
     // Ignore the 31 bit stream id
     m_read_ptr += 4;

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -55,7 +55,7 @@ parser::parser()
 {}
 
 boost::tribool parser::parse(http_protocol_info& http_info,
-                             boost::system::error_code& ec,
+                             asio::error_code& ec,
                              const decompressor_ptr& decompressor,
                              const char *packet_ptr,
                              boost::uint32_t& length_packet,
@@ -139,7 +139,7 @@ boost::uint32_t parser::get_control_frame_stream_id(const char *ptr)
     return four_bytes & 0x7FFFFFFF;
 }
     
-boost::tribool parser::parse_spdy_frame(boost::system::error_code& ec,
+boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
                                         const decompressor_ptr& decompressor,
                                         http_protocol_info& http_info,
                                         boost::uint32_t& length_packet,
@@ -261,7 +261,7 @@ void parser::create_error_category(void)
     m_error_category_ptr = &UNIQUE_ERROR_CATEGORY;
 }
 
-bool parser::populate_frame(boost::system::error_code& ec,
+bool parser::populate_frame(asio::error_code& ec,
                             spdy_control_frame_info& frame,
                             boost::uint32_t& length_packet,
                             boost::uint32_t& stream_id,
@@ -345,7 +345,7 @@ bool parser::populate_frame(boost::system::error_code& ec,
     return true;
 }
 
-void parser::parse_header_payload(boost::system::error_code &ec,
+void parser::parse_header_payload(asio::error_code &ec,
                                   const decompressor_ptr& decompressor,
                                   const spdy_control_frame_info& frame,
                                   http_protocol_info& http_info,
@@ -458,7 +458,7 @@ void parser::parse_header_payload(boost::system::error_code &ec,
     }
 }
 
-void parser::parse_spdy_data(boost::system::error_code& /* ec */,
+void parser::parse_spdy_data(asio::error_code& /* ec */,
                              const spdy_control_frame_info& frame,
                              boost::uint32_t /* stream_id */,
                              http_protocol_info& http_info)
@@ -469,7 +469,7 @@ void parser::parse_spdy_data(boost::system::error_code& /* ec */,
     }
 }
 
-void parser::parse_spdy_rst_stream(boost::system::error_code& /* ec */,
+void parser::parse_spdy_rst_stream(asio::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
     boost::uint32_t status_code = 0;
@@ -495,7 +495,7 @@ void parser::parse_spdy_rst_stream(boost::system::error_code& /* ec */,
     }
 }
 
-void parser::parse_spdy_ping_frame(boost::system::error_code& /* ec */,
+void parser::parse_spdy_ping_frame(asio::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
     // First complete the check for size 
@@ -516,13 +516,13 @@ void parser::parse_spdy_ping_frame(boost::system::error_code& /* ec */,
     PION_LOG_INFO(m_logger, "SPDY " << "Ping ID is : " << ping_id);
 }
 
-void parser::parse_spdy_settings_frame(boost::system::error_code& /* ec */,
+void parser::parse_spdy_settings_frame(asio::error_code& /* ec */,
                                        const spdy_control_frame_info& /* frame */)
 {
     // Can ignore this frame for our purposes
 }
 
-void parser::parse_spdy_goaway_frame(boost::system::error_code &ec,
+void parser::parse_spdy_goaway_frame(asio::error_code &ec,
                                      const spdy_control_frame_info& frame)
 {
     // First complete the check for size
@@ -557,7 +557,7 @@ void parser::parse_spdy_goaway_frame(boost::system::error_code &ec,
     
 }
 
-void parser::parse_spdy_window_update_frame(boost::system::error_code& /* ec */,
+void parser::parse_spdy_window_update_frame(asio::error_code& /* ec */,
                                             const spdy_control_frame_info& /* frame */)
 {
     // TBD : Do we really need this for our purpose

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -20,7 +20,7 @@ namespace pion {    // begin namespace pion
 namespace spdy {    // begin namespace spdy
 
 /// RST stream status string from code, return NULL for unknown status code
-static char const* rst_stream_status(uint32_t rst_stream_status_code)
+static char const* rst_stream_status(ustd::int32_t rst_stream_status_code)
 {
     switch (rst_stream_status_code)
     {
@@ -57,8 +57,8 @@ boost::tribool parser::parse(http_protocol_info& http_info,
                              asio::error_code& ec,
                              const decompressor_ptr& decompressor,
                              const char *packet_ptr,
-                             uint32_t& length_packet,
-                             uint32_t current_stream_count)
+                             ustd::int32_t& length_packet,
+                             ustd::int32_t current_stream_count)
 {
     // initialize read position
     set_read_ptr(packet_ptr);
@@ -72,9 +72,9 @@ bool parser::is_spdy_control_frame(const char *ptr)
     // Parse further for higher accuracy
     
     // Get the control bit
-    uint8_t control_bit;
-    uint16_t version, type;
-    uint16_t byte_value = algorithm::to_uint16(ptr);
+    ustd::int8_t control_bit;
+    ustd::int16_t version, type;
+    ustd::int16_t byte_value = algorithm::to_uint16(ptr);
     control_bit = byte_value >> (sizeof(short) * CHAR_BIT - 1);
 
     if (!control_bit) return false;
@@ -82,7 +82,7 @@ bool parser::is_spdy_control_frame(const char *ptr)
     // Control bit is set; This is a control frame
     
     // Get the version number
-    uint16_t two_bytes = algorithm::to_uint16(ptr);
+    ustd::int16_t two_bytes = algorithm::to_uint16(ptr);
     version = two_bytes & 0x7FFF;
     
     if(version < 1 || version > 3){
@@ -118,7 +118,7 @@ spdy_frame_type parser::get_spdy_frame_type(const char *ptr)
      */
     
     spdy_frame_type spdy_frame;
-    uint8_t first_byte = *((unsigned char *)ptr);
+    ustd::int8_t first_byte = *((unsigned char *)ptr);
     if(first_byte == 0x80){
         spdy_frame = spdy_control_frame;
     }else if(first_byte == 0x0){
@@ -129,27 +129,27 @@ spdy_frame_type parser::get_spdy_frame_type(const char *ptr)
     return spdy_frame;
 }
     
-uint32_t parser::get_control_frame_stream_id(const char *ptr)
+ustd::int32_t parser::get_control_frame_stream_id(const char *ptr)
 {
     // The stream ID for control frames is at a 8 bit offser from start
     ptr += 8;
 
-    uint32_t four_bytes = algorithm::to_uint32(ptr);
+    ustd::int32_t four_bytes = algorithm::to_uint32(ptr);
     return four_bytes & 0x7FFFFFFF;
 }
     
 boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
                                         const decompressor_ptr& decompressor,
                                         http_protocol_info& http_info,
-                                        uint32_t& length_packet,
-                                        uint32_t current_stream_count)
+                                        ustd::int32_t& length_packet,
+                                        ustd::int32_t current_stream_count)
 {
     boost::tribool rc = true;
     
     // Verify that this is a spdy frame
     
     BOOST_ASSERT(m_read_ptr);
-    uint8_t first_byte = (uint8_t)*m_read_ptr;
+    ustd::int8_t first_byte = (ustd::int8_t)*m_read_ptr;
     if (first_byte != 0x80 && first_byte != 0x0) {
         // This is not a SPDY frame, throw an error
         PION_LOG_ERROR(m_logger, "Invalid SPDY Frame");
@@ -157,9 +157,9 @@ boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
         return false;
     }
     
-    uint8_t              control_bit;
+    ustd::int8_t              control_bit;
     spdy_control_frame_info     frame;
-    uint32_t             stream_id = 0;
+    ustd::int32_t             stream_id = 0;
     
     ec.clear();
 
@@ -173,7 +173,7 @@ boost::tribool parser::parse_spdy_frame(asio::error_code& ec,
     
     BOOST_ASSERT(stream_id != 0);
     
-    control_bit = (uint8_t)frame.control_bit;
+    control_bit = (ustd::int8_t)frame.control_bit;
     
     // There is a possibility that there are more than one SPDY frames in one TCP frame
     if(length_packet > frame.length){
@@ -262,13 +262,13 @@ void parser::create_error_category(void)
 
 bool parser::populate_frame(asio::error_code& ec,
                             spdy_control_frame_info& frame,
-                            uint32_t& length_packet,
-                            uint32_t& stream_id,
+                            ustd::int32_t& length_packet,
+                            ustd::int32_t& stream_id,
                             http_protocol_info& http_info)
 {
     // Get the control bit
-    uint8_t control_bit;
-    uint16_t byte_value = algorithm::to_uint16(m_read_ptr);
+    ustd::int8_t control_bit;
+    ustd::int16_t byte_value = algorithm::to_uint16(m_read_ptr);
     control_bit = byte_value >> (sizeof(short) * CHAR_BIT - 1);
     
     frame.control_bit = (control_bit != 0);
@@ -278,7 +278,7 @@ bool parser::populate_frame(asio::error_code& ec,
         // Control bit is set; This is a control frame
         
         // Get the version number
-        uint16_t two_bytes = algorithm::to_uint16(m_read_ptr);
+        ustd::int16_t two_bytes = algorithm::to_uint16(m_read_ptr);
         frame.version = two_bytes & 0x7FFF;
         
         // Increment the read pointer
@@ -304,7 +304,7 @@ bool parser::populate_frame(asio::error_code& ec,
         frame.type = SPDY_DATA;
         frame.version = 0; /* Version doesn't apply to DATA. */
         // Get the stream id
-        uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+        ustd::int32_t four_bytes = algorithm::to_uint32(m_read_ptr);
         stream_id = four_bytes & 0x7FFFFFFF;
         
         http_info.stream_id = stream_id;
@@ -321,12 +321,12 @@ bool parser::populate_frame(asio::error_code& ec,
     http_info.data_offset +=2;
     
     // Get the flags
-    frame.flags = (uint8_t)*m_read_ptr;
+    frame.flags = (ustd::int8_t)*m_read_ptr;
     
     // Increment the read pointer
     
     // Get the length
-    uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+    ustd::int32_t four_bytes = algorithm::to_uint32(m_read_ptr);
     frame.length = four_bytes & 0xFFFFFF;
     
     // Increment the read pointer
@@ -348,14 +348,14 @@ void parser::parse_header_payload(asio::error_code &ec,
                                   const decompressor_ptr& decompressor,
                                   const spdy_control_frame_info& frame,
                                   http_protocol_info& http_info,
-                                  uint32_t /* current_stream_count */)
+                                  ustd::int32_t /* current_stream_count */)
 {
-    uint32_t stream_id = 0;
-    uint32_t header_block_length = frame.length;
+    ustd::int32_t stream_id = 0;
+    ustd::int32_t header_block_length = frame.length;
     
     // Get the 31 bit stream id
     
-    uint32_t four_bytes = algorithm::to_uint32(m_read_ptr);
+    ustd::int32_t four_bytes = algorithm::to_uint32(m_read_ptr);
     stream_id = four_bytes & 0x7FFFFFFF;
     
     m_read_ptr += 4;
@@ -416,37 +416,37 @@ void parser::parse_header_payload(asio::error_code &ec,
     // and it is 32 bit in SPDYv3
     
     // TBD : Add support for SPDYv3
-    uint16_t num_name_val_pairs = algorithm::to_uint16(m_uncompressed_ptr);
+    ustd::int16_t num_name_val_pairs = algorithm::to_uint16(m_uncompressed_ptr);
     
     m_uncompressed_ptr += 2;
     
     std::string content_type = "";
     std::string content_encoding = "";
     
-    for(uint16_t count = 0; count < num_name_val_pairs; ++count){
+    for(ustd::int16_t count = 0; count < num_name_val_pairs; ++count){
         
         
         // Get the length of the name
-        uint16_t length_name = algorithm::to_uint16(m_uncompressed_ptr);
+        ustd::int16_t length_name = algorithm::to_uint16(m_uncompressed_ptr);
         std::string name = "";
         
         m_uncompressed_ptr += 2;
         
         {
-            for(uint16_t count = 0; count < length_name; ++count){
+            for(ustd::int16_t count = 0; count < length_name; ++count){
                 name.push_back(*(m_uncompressed_ptr+count));
             }
             m_uncompressed_ptr += length_name;
         }
         
         // Get the length of the value
-        uint16_t length_value = algorithm::to_uint16(m_uncompressed_ptr);
+        ustd::int16_t length_value = algorithm::to_uint16(m_uncompressed_ptr);
         std::string value = "";
         
         m_uncompressed_ptr += 2;
         
         {
-            for(uint16_t count = 0; count < length_value; ++count){
+            for(ustd::int16_t count = 0; count < length_value; ++count){
                 value.push_back(*(m_uncompressed_ptr+count));
             }
             m_uncompressed_ptr += length_value;
@@ -459,7 +459,7 @@ void parser::parse_header_payload(asio::error_code &ec,
 
 void parser::parse_spdy_data(asio::error_code& /* ec */,
                              const spdy_control_frame_info& frame,
-                             uint32_t /* stream_id */,
+                             ustd::int32_t /* stream_id */,
                              http_protocol_info& http_info)
 {
     // This marks the finish flag
@@ -471,7 +471,7 @@ void parser::parse_spdy_data(asio::error_code& /* ec */,
 void parser::parse_spdy_rst_stream(asio::error_code& /* ec */,
                                    const spdy_control_frame_info& frame)
 {
-    uint32_t status_code = 0;
+    ustd::int32_t status_code = 0;
     
     // First complete the check for size and flag
     // The flag for RST frame should be 0, The length should be 8
@@ -503,7 +503,7 @@ void parser::parse_spdy_ping_frame(asio::error_code& /* ec */,
         return;
     }
   
-    uint32_t ping_id = 0;
+    ustd::int32_t ping_id = 0;
     
     // Get the 32 bit ping id
     
@@ -530,7 +530,7 @@ void parser::parse_spdy_goaway_frame(asio::error_code &ec,
         return;
     }
     
-    uint32_t status_code = 0;
+    ustd::int32_t status_code = 0;
     
     // Ignore the 31 bit stream id
     m_read_ptr += 4;

--- a/src/spdy_parser.cpp
+++ b/src/spdy_parser.cpp
@@ -8,7 +8,6 @@
 //
 
 #include <cstdlib>
-#include <boost/regex.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/asio/detail/socket_ops.hpp>
 #include <pion/algorithm.hpp>

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -8,10 +8,9 @@
 //
 
 #include <asio.hpp>
-#include <boost/bind.hpp>
-#include <boost/thread/mutex.hpp>
 #include <pion/admin_rights.hpp>
 #include <pion/tcp/server.hpp>
+#include <mutex>
 
 
 namespace pion {    // begin namespace pion

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -71,7 +71,7 @@ server::server(const asio::ip::tcp::endpoint& endpoint)
 void server::start(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    std::unique_lock<std::mutex> server_lock(m_mutex);
 
     if (! m_is_listening) {
         PION_LOG_INFO(m_logger, "Starting server on port " << get_port());
@@ -113,7 +113,7 @@ void server::start(void)
 void server::stop(bool wait_until_finished)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    std::unique_lock<std::mutex> server_lock(m_mutex);
 
     if (m_is_listening) {
         PION_LOG_INFO(m_logger, "Shutting down server on port " << get_port());
@@ -150,7 +150,7 @@ void server::stop(bool wait_until_finished)
 
 void server::join(void)
 {
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    std::unique_lock<std::mutex> server_lock(m_mutex);
     while (m_is_listening) {
         // sleep until server_has_stopped condition is signaled
         m_server_has_stopped.wait(server_lock);
@@ -173,7 +173,7 @@ void server::set_ssl_key_file(const std::string& pem_key_file)
 void server::listen(void)
 {
     // lock mutex for thread safety
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    std::unique_lock<std::mutex> server_lock(m_mutex);
     
     if (m_is_listening) {
         // create a new TCP connection object
@@ -246,7 +246,7 @@ void server::handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
 
 void server::finish_connection(const tcp::connection_ptr& tcp_conn)
 {
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    std::unique_lock<std::mutex> server_lock(m_mutex);
     if (m_is_listening && tcp_conn->get_keep_alive()) {
         
         // keep the connection alive
@@ -288,7 +288,7 @@ std::size_t server::prune_connections(void)
 
 std::size_t server::get_connections(void) const
 {
-    boost::mutex::scoped_lock server_lock(m_mutex);
+    std::unique_lock<std::mutex> server_lock(m_mutex);
     return (m_is_listening ? (m_conn_pool.size() - 1) : m_conn_pool.size());
 }
 

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -7,7 +7,7 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread/mutex.hpp>
 #include <pion/admin_rights.hpp>
@@ -25,19 +25,19 @@ server::server(scheduler& sched, const unsigned int tcp_port)
     m_active_scheduler(sched),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(boost::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
+    m_endpoint(asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
 {}
     
-server::server(scheduler& sched, const boost::asio::ip::tcp::endpoint& endpoint)
+server::server(scheduler& sched, const asio::ip::tcp::endpoint& endpoint)
     : m_logger(PION_GET_LOGGER("pion.tcp.server")),
     m_active_scheduler(sched),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
@@ -49,19 +49,19 @@ server::server(const unsigned int tcp_port)
     m_default_scheduler(), m_active_scheduler(m_default_scheduler),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
-    m_endpoint(boost::asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
+    m_endpoint(asio::ip::tcp::v4(), tcp_port), m_ssl_flag(false), m_is_listening(false)
 {}
 
-server::server(const boost::asio::ip::tcp::endpoint& endpoint)
+server::server(const asio::ip::tcp::endpoint& endpoint)
     : m_logger(PION_GET_LOGGER("pion.tcp.server")),
     m_default_scheduler(), m_active_scheduler(m_default_scheduler),
     m_tcp_acceptor(m_active_scheduler.get_io_service()),
 #ifdef PION_HAVE_SSL
-    m_ssl_context(m_active_scheduler.get_io_service(), boost::asio::ssl::context::sslv23),
+    m_ssl_context(m_active_scheduler.get_io_service(), asio::ssl::context::sslv23),
 #else
     m_ssl_context(0),
 #endif
@@ -86,7 +86,7 @@ void server::start(void)
             // allow the acceptor to reuse the address (i.e. SO_REUSEADDR)
             // ...except when running not on Windows - see http://msdn.microsoft.com/en-us/library/ms740621%28VS.85%29.aspx
 #ifndef PION_WIN32
-            m_tcp_acceptor.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+            m_tcp_acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
 #endif
             m_tcp_acceptor.bind(m_endpoint);
             if (m_endpoint.port() == 0) {
@@ -126,7 +126,7 @@ void server::stop(bool wait_until_finished)
         if (! wait_until_finished) {
             // this terminates any other open connections
             std::for_each(m_conn_pool.begin(), m_conn_pool.end(),
-                          boost::bind(&connection::close, _1));
+                          std::bind(&connection::close, std::placeholders::_1));
         }
     
         // wait for all pending connections to complete
@@ -162,11 +162,11 @@ void server::set_ssl_key_file(const std::string& pem_key_file)
     // configure server for SSL
     set_ssl_flag(true);
 #ifdef PION_HAVE_SSL
-    m_ssl_context.set_options(boost::asio::ssl::context::default_workarounds
-                              | boost::asio::ssl::context::no_sslv2
-                              | boost::asio::ssl::context::single_dh_use);
-    m_ssl_context.use_certificate_file(pem_key_file, boost::asio::ssl::context::pem);
-    m_ssl_context.use_private_key_file(pem_key_file, boost::asio::ssl::context::pem);
+    m_ssl_context.set_options(asio::ssl::context::default_workarounds
+                              | asio::ssl::context::no_sslv2
+                              | asio::ssl::context::single_dh_use);
+    m_ssl_context.use_certificate_file(pem_key_file, asio::ssl::context::pem);
+    m_ssl_context.use_private_key_file(pem_key_file, asio::ssl::context::pem);
 #endif
 }
 
@@ -179,8 +179,8 @@ void server::listen(void)
         // create a new TCP connection object
         tcp::connection_ptr new_connection(connection::create(get_io_service(),
                                                               m_ssl_context, m_ssl_flag,
-                                                              boost::bind(&server::finish_connection,
-                                                                          this, _1)));
+                                                              std::bind(&server::finish_connection,
+                                                                          this, std::placeholders::_1)));
         
         // prune connections that finished uncleanly
         prune_connections();
@@ -190,14 +190,14 @@ void server::listen(void)
         
         // use the object to accept a new connection
         new_connection->async_accept(m_tcp_acceptor,
-                                     boost::bind(&server::handle_accept,
+                                     std::bind(&server::handle_accept,
                                                  this, new_connection,
-                                                 boost::asio::placeholders::error));
+                                                 std::placeholders::_1));
     }
 }
 
 void server::handle_accept(const tcp::connection_ptr& tcp_conn,
-                             const boost::system::error_code& accept_error)
+                             const asio::error_code& accept_error)
 {
     if (accept_error) {
         // an error occured while trying to a accept a new connection
@@ -219,9 +219,9 @@ void server::handle_accept(const tcp::connection_ptr& tcp_conn,
         // handle the new connection
 #ifdef PION_HAVE_SSL
         if (tcp_conn->get_ssl_flag()) {
-            tcp_conn->async_handshake_server(boost::bind(&server::handle_ssl_handshake,
+            tcp_conn->async_handshake_server(std::bind(&server::handle_ssl_handshake,
                                                          this, tcp_conn,
-                                                         boost::asio::placeholders::error));
+                                                         std::placeholders::_1));
         } else
 #endif
             // not SSL -> call the handler immediately
@@ -230,7 +230,7 @@ void server::handle_accept(const tcp::connection_ptr& tcp_conn,
 }
 
 void server::handle_ssl_handshake(const tcp::connection_ptr& tcp_conn,
-                                   const boost::system::error_code& handshake_error)
+                                   const asio::error_code& handshake_error)
 {
     if (handshake_error) {
         // an error occured while trying to establish the SSL connection

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -7,9 +7,8 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
+#include <functional>
 #include <pion/tcp/timer.hpp>
-#include <boost/bind.hpp>
-
 
 namespace pion {    // begin namespace pion
 namespace tcp {     // begin namespace tcp
@@ -23,13 +22,12 @@ timer::timer(const tcp::connection_ptr& conn_ptr)
 {
 }
 
-void timer::start(const boost::uint32_t seconds)
+void timer::start(const uint32_t seconds)
 {
     boost::mutex::scoped_lock timer_lock(m_mutex);
     m_timer_active = true;
     m_timer.expires_from_now(boost::posix_time::seconds(seconds));
-    m_timer.async_wait(boost::bind(&timer::timer_callback,
-        shared_from_this(), _1));
+    m_timer.async_wait(std::bind(&timer::timer_callback, shared_from_this(), std::placeholders::_1));
 }
 
 void timer::cancel(void)
@@ -40,7 +38,7 @@ void timer::cancel(void)
         m_timer.cancel();
 }
 
-void timer::timer_callback(const boost::system::error_code& /* ec */)
+void timer::timer_callback(const asio::error_code& /* ec */)
 {
     boost::mutex::scoped_lock timer_lock(m_mutex);
     m_timer_active = false;

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -24,7 +24,7 @@ timer::timer(const tcp::connection_ptr& conn_ptr)
 
 void timer::start(const uint32_t seconds)
 {
-    boost::mutex::scoped_lock timer_lock(m_mutex);
+    std::unique_lock<std::mutex> timer_lock(m_mutex);
     m_timer_active = true;
     m_timer.expires_from_now(boost::posix_time::seconds(seconds));
     m_timer.async_wait(std::bind(&timer::timer_callback, shared_from_this(), std::placeholders::_1));
@@ -32,7 +32,7 @@ void timer::start(const uint32_t seconds)
 
 void timer::cancel(void)
 {
-    boost::mutex::scoped_lock timer_lock(m_mutex);
+    std::unique_lock<std::mutex> timer_lock(m_mutex);
     m_was_cancelled = true;
     if (m_timer_active)
         m_timer.cancel();
@@ -40,7 +40,7 @@ void timer::cancel(void)
 
 void timer::timer_callback(const asio::error_code& /* ec */)
 {
-    boost::mutex::scoped_lock timer_lock(m_mutex);
+    std::unique_lock<std::mutex> timer_lock(m_mutex);
     m_timer_active = false;
     if (! m_was_cancelled)
         m_conn_ptr->cancel();

--- a/src/tcp_timer.cpp
+++ b/src/tcp_timer.cpp
@@ -22,7 +22,7 @@ timer::timer(const tcp::connection_ptr& conn_ptr)
 {
 }
 
-void timer::start(const uint32_t seconds)
+void timer::start(const ustd::int32_t seconds)
 {
     std::unique_lock<std::mutex> timer_lock(m_mutex);
     m_timer_active = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 endif()
 
 message("PLUGIN_PATH = ${PLUGIN_PATH}; EXECUTABLE_OUTPUT_PATH = ${EXECUTABLE_OUTPUT_PATH}")
+include_directories(${PLUGIN_PATH})
 
 add_custom_target(prepare_path
     COMMAND cmake -DPION_PLUGIN_PATH=${PLUGIN_PATH} -DPION_SRC_ROOT=${PION_SRC_ROOT} -P ${PION_SRC_ROOT}/cmake/GenTestInclude.cmake

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,8 @@
 cmake_minimum_required(VERSION 2.8.10 FATAL_ERROR)
 
 set(PROJECT_NAME piontests)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
+
 project(${PROJECT_NAME} CXX)
 
 # add test plugins

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -193,20 +193,20 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     
     algorithm::from_uint8(buf, 129U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x81);
-    BOOST_CHECK_EQUAL(algorithm::to_int8(buf), int8_t(0x81));
+    BOOST_CHECK_EQUAL(algorithm::to_int8(buf), std::int8_t(0x81));
     BOOST_CHECK_EQUAL(algorithm::to_uint8(buf), 129U);
 
     algorithm::from_uint16(buf, 32769U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x80);
     BOOST_CHECK_EQUAL(buf[1], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int16(buf), int16_t(0x8001));
+    BOOST_CHECK_EQUAL(algorithm::to_int16(buf), std::int16_t(0x8001));
     BOOST_CHECK_EQUAL(algorithm::to_uint16(buf), 32769U);
 
     algorithm::from_uint24(buf, 9642497U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x93);
     BOOST_CHECK_EQUAL(buf[1], (char)0x22);
     BOOST_CHECK_EQUAL(buf[2], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int24(buf), int32_t(0x932201));
+    BOOST_CHECK_EQUAL(algorithm::to_int24(buf), std::int32_t(0x932201));
     BOOST_CHECK_EQUAL(algorithm::to_uint24(buf), 9642497U);
 
     algorithm::from_uint32(buf, 2147680769UL);
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[1], (char)0x03);
     BOOST_CHECK_EQUAL(buf[2], (char)0x02);
     BOOST_CHECK_EQUAL(buf[3], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), int32_t(0x80030201));
+    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), std::int32_t(0x80030201));
     BOOST_CHECK_EQUAL(algorithm::to_uint32(buf), 2147680769UL);
 
     algorithm::from_uint32(buf, 1427U);
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[1], (char)0x00);
     BOOST_CHECK_EQUAL(buf[2], (char)0x05);
     BOOST_CHECK_EQUAL(buf[3], (char)0x93);
-    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), int32_t(0x00000593));
+    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), std::int32_t(0x00000593));
     BOOST_CHECK_EQUAL(algorithm::to_uint32(buf), 1427U);
 
     algorithm::from_uint64(buf, 9223378168241586176ULL);
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[5], (char)0x22);
     BOOST_CHECK_EQUAL(buf[6], (char)0x00);
     BOOST_CHECK_EQUAL(buf[7], (char)0x00);
-    BOOST_CHECK_EQUAL(algorithm::to_int64(buf), int64_t(0x8000059393220000ULL));
+    BOOST_CHECK_EQUAL(algorithm::to_int64(buf), std::int64_t(0x8000059393220000ULL));
     BOOST_CHECK_EQUAL(algorithm::to_uint64(buf), 9223378168241586176ULL);
 }
 

--- a/tests/algorithm_tests.cpp
+++ b/tests/algorithm_tests.cpp
@@ -193,20 +193,20 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     
     algorithm::from_uint8(buf, 129U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x81);
-    BOOST_CHECK_EQUAL(algorithm::to_int8(buf), boost::int8_t(0x81));
+    BOOST_CHECK_EQUAL(algorithm::to_int8(buf), int8_t(0x81));
     BOOST_CHECK_EQUAL(algorithm::to_uint8(buf), 129U);
 
     algorithm::from_uint16(buf, 32769U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x80);
     BOOST_CHECK_EQUAL(buf[1], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int16(buf), boost::int16_t(0x8001));
+    BOOST_CHECK_EQUAL(algorithm::to_int16(buf), int16_t(0x8001));
     BOOST_CHECK_EQUAL(algorithm::to_uint16(buf), 32769U);
 
     algorithm::from_uint24(buf, 9642497U);
     BOOST_CHECK_EQUAL(buf[0], (char)0x93);
     BOOST_CHECK_EQUAL(buf[1], (char)0x22);
     BOOST_CHECK_EQUAL(buf[2], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int24(buf), boost::int32_t(0x932201));
+    BOOST_CHECK_EQUAL(algorithm::to_int24(buf), int32_t(0x932201));
     BOOST_CHECK_EQUAL(algorithm::to_uint24(buf), 9642497U);
 
     algorithm::from_uint32(buf, 2147680769UL);
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[1], (char)0x03);
     BOOST_CHECK_EQUAL(buf[2], (char)0x02);
     BOOST_CHECK_EQUAL(buf[3], (char)0x01);
-    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), boost::int32_t(0x80030201));
+    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), int32_t(0x80030201));
     BOOST_CHECK_EQUAL(algorithm::to_uint32(buf), 2147680769UL);
 
     algorithm::from_uint32(buf, 1427U);
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[1], (char)0x00);
     BOOST_CHECK_EQUAL(buf[2], (char)0x05);
     BOOST_CHECK_EQUAL(buf[3], (char)0x93);
-    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), boost::int32_t(0x00000593));
+    BOOST_CHECK_EQUAL(algorithm::to_int32(buf), int32_t(0x00000593));
     BOOST_CHECK_EQUAL(algorithm::to_uint32(buf), 1427U);
 
     algorithm::from_uint64(buf, 9223378168241586176ULL);
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(testCharFromToIntRoutines) {
     BOOST_CHECK_EQUAL(buf[5], (char)0x22);
     BOOST_CHECK_EQUAL(buf[6], (char)0x00);
     BOOST_CHECK_EQUAL(buf[7], (char)0x00);
-    BOOST_CHECK_EQUAL(algorithm::to_int64(buf), boost::int64_t(0x8000059393220000ULL));
+    BOOST_CHECK_EQUAL(algorithm::to_int64(buf), int64_t(0x8000059393220000ULL));
     BOOST_CHECK_EQUAL(algorithm::to_uint64(buf), 9223378168241586176ULL);
 }
 

--- a/tests/file_service_tests.cpp
+++ b/tests/file_service_tests.cpp
@@ -8,8 +8,6 @@
 //
 
 #include <asio.hpp>
-#include <boost/bind.hpp>
-#include <boost/scoped_array.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -264,7 +262,7 @@ public:
         BOOST_CHECK(m_content_length > 0);
 
         // read in the response content
-        boost::scoped_array<char> content_buf(new char[m_content_length + 1]);
+        std::unique_ptr<char[]> content_buf(new char[m_content_length + 1]);
         BOOST_CHECK(m_http_stream.read(content_buf.get(), m_content_length));
         content_buf[m_content_length] = '\0';
         

--- a/tests/file_service_tests.cpp
+++ b/tests/file_service_tests.cpp
@@ -7,10 +7,9 @@
 // See http://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
@@ -109,7 +108,7 @@ public:
         boost::filesystem::remove_all("sandbox");
     }
     
-    inline boost::asio::io_service& get_io_service(void) { return m_scheduler.get_io_service(); }
+    inline asio::io_service& get_io_service(void) { return m_scheduler.get_io_service(); }
     
     single_service_scheduler	m_scheduler;
 	http::plugin_server			m_server;
@@ -170,7 +169,7 @@ public:
         m_server.start();
 
         // open a connection
-        boost::asio::ip::tcp::endpoint http_endpoint(boost::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
+        asio::ip::tcp::endpoint http_endpoint(asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
         m_http_stream.connect(http_endpoint);
     }
     ~RunningFileService_F() {
@@ -215,7 +214,7 @@ public:
         BOOST_REQUIRE(rx_matches.size() == 2);
 
         // extract response status code
-        response_code = boost::lexical_cast<unsigned int>(rx_matches[1]);
+        response_code = std::stoul(rx_matches[1]);
         BOOST_CHECK_EQUAL(response_code, expected_response_code);
 
         // read response headers
@@ -230,7 +229,7 @@ public:
             // check for content-length response header
             if (boost::regex_match(rsp_line, rx_matches, regex_content_length_header)) {
                 if (rx_matches.size() == 2)
-                    m_content_length = boost::lexical_cast<unsigned long>(rx_matches[1]);
+                    m_content_length = std::stoul(rx_matches[1]);
             }
         }
 
@@ -275,7 +274,7 @@ public:
     }
     
     unsigned long m_content_length;
-    boost::asio::ip::tcp::iostream m_http_stream;
+    asio::ip::tcp::iostream m_http_stream;
     std::map<std::string, std::string> m_response_headers;
 };
 
@@ -585,7 +584,7 @@ public:
     enum _size_constants { MAX_CHUNK_SIZE = 10 };
 
     RunningFileServiceWithMaxChunkSizeSet_F() {
-        m_server.set_service_option("/resource1", "max_chunk_size", boost::lexical_cast<std::string>(MAX_CHUNK_SIZE));
+        m_server.set_service_option("/resource1", "max_chunk_size", std::to_string(MAX_CHUNK_SIZE));
 
         // make sure the length of the test data is in the range expected by the tests
         m_file4_len = strlen(g_file4_contents);
@@ -668,8 +667,8 @@ BOOST_AUTO_TEST_CASE(checkResponseToHTTP_1_1_Request) {
 BOOST_AUTO_TEST_CASE(checkHTTPMessageReceive) {
     // open (another) connection
     pion::tcp::connection tcp_conn(get_io_service());
-    boost::system::error_code error_code;
-    error_code = tcp_conn.connect(boost::asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
+    asio::error_code error_code;
+    error_code = tcp_conn.connect(asio::ip::address::from_string("127.0.0.1"), m_server.get_port());
     BOOST_REQUIRE(!error_code);
 
     // send request to the server

--- a/tests/http_message_tests.cpp
+++ b/tests/http_message_tests.cpp
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPRequestNoContent) {
     req.add_header("Test", "Something");
     
     // write to file
-    boost::system::error_code ec;
+    asio::error_code ec;
     req.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();
@@ -450,7 +450,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPResponseNoContent) {
     rsp.add_header("HeaderA", "a value");
     
     // write to file
-    boost::system::error_code ec;
+    asio::error_code ec;
     rsp.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPResponseNoContent) {
 }
 
 BOOST_AUTO_TEST_CASE(checkWriteReadMixedMessages) {
-    boost::system::error_code ec;
+    asio::error_code ec;
     http::request req;
     http::response rsp;
 
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(checkWriteHTTPRequestWithCookies) {
     req.add_cookie("a", "value");
     
     // write to file
-    boost::system::error_code ec;
+    asio::error_code ec;
     req.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(checkWriteHTTPResponseWithCookies) {
     rsp.add_cookie("a", "value");
 
     // write to file
-    boost::system::error_code ec;
+    asio::error_code ec;
     rsp.write(m_file, ec);
     BOOST_REQUIRE(! ec);
     m_file.flush();

--- a/tests/http_message_tests.cpp
+++ b/tests/http_message_tests.cpp
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPRequestNoContent) {
     // make sure we're now at EOF
     http::request req3;
     req3.read(m_file, ec);
-    BOOST_CHECK_EQUAL(ec.value(), boost::system::errc::io_error);
+    BOOST_CHECK_EQUAL(ec.value(), asio::error::eof);
     
     // check request read from file
     BOOST_CHECK_EQUAL(req2.get_resource(), "/test.html");
@@ -465,7 +465,7 @@ BOOST_AUTO_TEST_CASE(checkWriteReadHTTPResponseNoContent) {
     // make sure we're now at EOF
     http::response rsp3;
     rsp3.read(m_file, ec);
-    BOOST_CHECK_EQUAL(ec.value(), boost::system::errc::io_error);
+    BOOST_CHECK_EQUAL(ec.value(), asio::error::eof);
     
     // check response read from file
     BOOST_CHECK_EQUAL(rsp2.get_status_code(), 202U);

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(testParseHttpUri)
     std::string uri("http://127.0.0.1:80/folder/file.ext?q=uery");
     std::string proto;
     std::string host;
-    boost::uint16_t port = 0;
+    uint16_t port = 0;
     std::string path;
     std::string query;
 
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParser_MultipleResponseFrames)
     http::response http_response;
     asio::error_code ec;
 
-    boost::uint64_t total_bytes = 0;
+    uint64_t total_bytes = 0;
     for (int i=0; i <  frame_cnt - 1; i++ ) {
         response_parser.set_read_buffer((const char*)frames[i], sizes[i]);
         BOOST_CHECK( boost::indeterminate(response_parser.parse(http_response, ec)) );

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(testParseHttpUri)
     std::string uri("http://127.0.0.1:80/folder/file.ext?q=uery");
     std::string proto;
     std::string host;
-    uint16_t port = 0;
+    ustd::int16_t port = 0;
     std::string path;
     std::string query;
 
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParser_MultipleResponseFrames)
     http::response http_response;
     asio::error_code ec;
 
-    uint64_t total_bytes = 0;
+    ustd::int64_t total_bytes = 0;
     for (int i=0; i <  frame_cnt - 1; i++ ) {
         response_parser.set_read_buffer((const char*)frames[i], sizes[i]);
         BOOST_CHECK( boost::indeterminate(response_parser.parse(http_response, ec)) );

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -482,8 +482,8 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponse)
     BOOST_CHECK_EQUAL(response_parser.get_total_bytes_read(), sizeof(response_data_1));
     BOOST_CHECK_EQUAL(response_parser.get_content_bytes_read(), 117UL);
 
-    boost::regex content_regex("^GIF89a.*");
-    BOOST_CHECK(boost::regex_match(http_response.get_content(), content_regex));
+    std::regex content_regex("^GIF89a[^]*");
+    BOOST_CHECK(std::regex_match(http_response.get_content(), content_regex));
 }
 
 BOOST_AUTO_TEST_CASE(testHTTPParserBadRequest)
@@ -566,8 +566,8 @@ BOOST_AUTO_TEST_CASE(testHTTPParser_MultipleResponseFrames)
     BOOST_CHECK_EQUAL(response_parser.get_total_bytes_read(), total_bytes);
     BOOST_CHECK_EQUAL(response_parser.get_content_bytes_read(), 4712UL);
 
-    boost::regex content_regex(".*<title>Atomic\\sLabs:.*");
-    BOOST_CHECK(boost::regex_match(http_response.get_content(), content_regex));
+    std::regex content_regex("[^]*<title>Atomic\\sLabs:[^]*");
+    BOOST_CHECK(std::regex_match(http_response.get_content(), content_regex));
 }
 
 BOOST_AUTO_TEST_CASE(testHTTPParserWithSemicolons)

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleRequest)
     request_parser.set_read_buffer((const char*)request_data_1, sizeof(request_data_1));
 
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
 
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponse)
     response_parser.set_read_buffer((const char*)response_data_1, sizeof(response_data_1));
 
     http::response http_response;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(response_parser.parse(http_response, ec));
     BOOST_CHECK(!ec);
 
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserBadRequest)
     request_parser.set_read_buffer((const char*)request_data_bad, sizeof(request_data_bad));
 
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(!request_parser.parse(http_request, ec));
     BOOST_CHECK_EQUAL(ec.value(), http::parser::ERROR_VERSION_CHAR);
     BOOST_CHECK_EQUAL(ec.message(), "invalid version character");
@@ -505,7 +505,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponseWithSmallerMaxSize)
     response_parser.set_max_content_length(4);
 
     http::response http_response;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(response_parser.parse(http_response, ec));
     BOOST_CHECK(!ec);
 
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserSimpleResponseWithZeroMaxSize)
     response_parser.set_max_content_length(0);
 
     http::response http_response;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(response_parser.parse(http_response, ec));
     BOOST_CHECK(!ec);
 
@@ -547,7 +547,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParser_MultipleResponseFrames)
 
     http::parser response_parser(false);
     http::response http_response;
-    boost::system::error_code ec;
+    asio::error_code ec;
 
     boost::uint64_t total_bytes = 0;
     for (int i=0; i <  frame_cnt - 1; i++ ) {
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserWithSemicolons)
                                    sizeof(chunked_request_with_semicolon));
     
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
     
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserWithFooters)
                                    sizeof(chunked_request_with_footers));
     
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
     
@@ -617,7 +617,7 @@ BOOST_AUTO_TEST_CASE(testHTTPParserWithErrorInFooters)
                                    sizeof(chunked_request_with_error_in_footers));
     
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     // The HTTP Packet does not contain any footer value associated with the footer key
     // This will lead to any error within the parse_headers() method
@@ -642,7 +642,7 @@ BOOST_AUTO_TEST_CASE(testHTTP_0_9_RequestParser)
     request_parser.set_read_buffer(request_str.c_str(), request_str.length());
     
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
 
     BOOST_CHECK(!ec);
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE(testHTTP_0_9_ResponseParser)
     request_parser.set_read_buffer(request_str.c_str(), request_str.length());
     
     http::request http_request;
-    boost::system::error_code ec;
+    asio::error_code ec;
     BOOST_CHECK(request_parser.parse(http_request, ec));
     BOOST_CHECK(!ec);
 

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(testParseMultipartFormData)
 BOOST_AUTO_TEST_CASE(testParseGarbageMultipartFormData)
 {
     static const size_t BUF_SIZE = 1024;
-    boost::scoped_array<char> buf_ptr(new char[BUF_SIZE]);
+    std::unique_ptr<char[]> buf_ptr(new char[BUF_SIZE]);
     memset(buf_ptr.get(), 'x', BUF_SIZE);
     ihash_multimap params;
     BOOST_CHECK(!http::parser::parse_multipart_form_data(params, "multipart/form-data; boundary=----WebKitFormBoundarynqrI4c1BfROrEpu7", buf_ptr.get(), BUF_SIZE));

--- a/tests/http_plugin_server_tests.cpp
+++ b/tests/http_plugin_server_tests.cpp
@@ -14,7 +14,6 @@
 #include <mutex>
 #include <regex>
 #include <condition_variable>
-#include <boost/scoped_array.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <pion/plugin.hpp>
@@ -271,7 +270,7 @@ public:
         BOOST_CHECK(response_code == 200);
         BOOST_CHECK(content_length > 0);
         if (content_length > 0) {
-            boost::scoped_array<char> content_buf(new char[content_length+1]);
+            std::unique_ptr<char[]> content_buf(new char[content_length+1]);
             BOOST_CHECK(http_stream.read(content_buf.get(), content_length));
         }
         
@@ -300,7 +299,7 @@ public:
         BOOST_REQUIRE(content_length > 0);
         
         // read in the response content
-        boost::scoped_array<char> content_buf(new char[content_length+1]);
+        std::unique_ptr<char[]> content_buf(new char[content_length+1]);
         BOOST_CHECK(http_stream.read(content_buf.get(), content_length));
         content_buf[content_length] = '\0';
         

--- a/tests/spdy_parser_tests.cpp
+++ b/tests/spdy_parser_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_SUITE(parser_S, parser_F)
 BOOST_AUTO_TEST_CASE(test_is_spdy_frame_methods)
 {
     // Try with a invalid SPDY frame
-    uint16_t sample_frame = 0xFF;
+    ustd::int16_t sample_frame = 0xFF;
     asio::error_code ec;
     
     BOOST_CHECK_EQUAL(parser::get_spdy_frame_type((const char *)&(sample_frame)), spdy_invalid_frame);
@@ -95,10 +95,10 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_reply_frame)
     http_protocol_info http_info;
     
     // The length is known for this packet
-    uint32_t length_packet = 1460;
+    ustd::int32_t length_packet = 1460;
     
     spdy_control_frame_info frame;
-    uint32_t                stream_id = 0;
+    ustd::int32_t                stream_id = 0;
     
     this->set_read_ptr((const char*)spdy_syn_reply_frame);
     
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_rst_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 30;
+    ustd::int32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_goaway_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 30;
+    ustd::int32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_frames)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 30;
+    ustd::int32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_ping_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 30;
+    ustd::int32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_stream_frame)
     http_protocol_info http_info;
     
     // The length is known for this packet
-    uint32_t length_packet = 294;
+    ustd::int32_t length_packet = 294;
     
     spdy_control_frame_info frame;
-    uint32_t                stream_id = 0;
+    ustd::int32_t                stream_id = 0;
     
     this->set_read_ptr((const char*)spdy_syn_stream_frame);
     
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_interleaved_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 1460;
+    ustd::int32_t length_packet = 1460;
     
     boost::tribool result = false;
     
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_header)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 1460;
+    ustd::int32_t length_packet = 1460;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_syn_stream_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    uint32_t length_packet = 294;
+    ustd::int32_t length_packet = 294;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_datastream_frame)
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
 
     http_protocol_info   http_info;
-    uint32_t length_packet = 1460;
+    ustd::int32_t length_packet = 1460;
 
     boost::tribool result = false;
     

--- a/tests/spdy_parser_tests.cpp
+++ b/tests/spdy_parser_tests.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(test_is_spdy_frame_methods)
 {
     // Try with a invalid SPDY frame
     boost::uint16_t sample_frame = 0xFF;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     BOOST_CHECK_EQUAL(parser::get_spdy_frame_type((const char *)&(sample_frame)), spdy_invalid_frame);
     BOOST_CHECK_EQUAL(parser::is_spdy_control_frame((const char *)&(sample_frame)), false);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_reply_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    asio::error_code ec;
     http_protocol_info http_info;
     
     // The length is known for this packet
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_rst_frame)
     // Parse a spdy rst frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_goaway_frame)
     // Parse a spdy go away frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_frames)
     // any unwanted conditions like seg faults etx
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_ping_frame)
     // Parse a spdy ping frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_stream_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    asio::error_code ec;
     http_protocol_info http_info;
     
     // The length is known for this packet
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_interleaved_frame)
     // Parse a spdy response frame
     
     http_protocol_info http_info;
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_header)
     // Parse a spdy response frame
     
     http_protocol_info          http_info;
-    boost::system::error_code   ec;
+    asio::error_code   ec;
     
     // Check for interleaved spdy frames
     // The length is known for this packet
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_syn_stream_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     // Check for interleaved spdy frames
     // The length is known for this packet
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_datastream_frame)
 {
     // Parse a spdy response frame
     
-    boost::system::error_code ec;
+    asio::error_code ec;
     
     // Check for interleaved spdy frames
     // The length is known for this packet

--- a/tests/spdy_parser_tests.cpp
+++ b/tests/spdy_parser_tests.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_SUITE(parser_S, parser_F)
 BOOST_AUTO_TEST_CASE(test_is_spdy_frame_methods)
 {
     // Try with a invalid SPDY frame
-    boost::uint16_t sample_frame = 0xFF;
+    uint16_t sample_frame = 0xFF;
     asio::error_code ec;
     
     BOOST_CHECK_EQUAL(parser::get_spdy_frame_type((const char *)&(sample_frame)), spdy_invalid_frame);
@@ -95,10 +95,10 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_reply_frame)
     http_protocol_info http_info;
     
     // The length is known for this packet
-    boost::uint32_t length_packet = 1460;
+    uint32_t length_packet = 1460;
     
     spdy_control_frame_info frame;
-    boost::uint32_t                stream_id = 0;
+    uint32_t                stream_id = 0;
     
     this->set_read_ptr((const char*)spdy_syn_reply_frame);
     
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_rst_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_goaway_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_frames)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_ping_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 30;
+    uint32_t length_packet = 30;
     
     boost::tribool result = false;
     
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_syn_stream_frame)
     http_protocol_info http_info;
     
     // The length is known for this packet
-    boost::uint32_t length_packet = 294;
+    uint32_t length_packet = 294;
     
     spdy_control_frame_info frame;
-    boost::uint32_t                stream_id = 0;
+    uint32_t                stream_id = 0;
     
     this->set_read_ptr((const char*)spdy_syn_stream_frame);
     
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_interleaved_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 1460;
+    uint32_t length_packet = 1460;
     
     boost::tribool result = false;
     
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(test_spdy_parse_header)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 1460;
+    uint32_t length_packet = 1460;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_syn_stream_frame)
     
     // Check for interleaved spdy frames
     // The length is known for this packet
-    boost::uint32_t length_packet = 294;
+    uint32_t length_packet = 294;
     
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
     
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(test_populate_http_info_datastream_frame)
     decompressor_ptr decompressor = (decompressor_ptr)new pion::spdy::decompressor();
 
     http_protocol_info   http_info;
-    boost::uint32_t length_packet = 1460;
+    uint32_t length_packet = 1460;
 
     boost::tribool result = false;
     

--- a/tests/tcp_server_tests.cpp
+++ b/tests/tcp_server_tests.cpp
@@ -8,11 +8,11 @@
 //
 
 #include <functional>
+#include <thread>
 #include <pion/config.hpp>
 #include <pion/scheduler.hpp>
 #include <pion/tcp/server.hpp>
 #include <asio.hpp>
-#include <boost/thread/thread.hpp>
 #include <boost/test/unit_test.hpp>
 #include <pion/http/request.hpp>
 #include <pion/http/response.hpp>

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(checkTCPConnectToAnotherStream) {
 
     // schedule another thread to listen for a TCP connection
     connection_handler conn_handler(std::bind(&tcp_stream_tests_F::sendHello, std::placeholders::_1));
-    boost::thread listener_thread(std::bind(&tcp_stream_tests_F::acceptConnection,
+    std::thread listener_thread(std::bind(&tcp_stream_tests_F::acceptConnection,
                                               this, conn_handler) );
     m_scheduler.add_active_user();
     m_accept_ready.wait(accept_lock);
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(checkSendAndReceiveBiggerThanBuffers) {
 
     // schedule another thread to listen for a TCP connection
     connection_handler conn_handler(std::bind(&tcp_stream_buffer_tests_F::sendBigBuffer, this, std::placeholders::_1));
-    boost::thread listener_thread(std::bind(&tcp_stream_buffer_tests_F::acceptConnection,
+    std::thread listener_thread(std::bind(&tcp_stream_buffer_tests_F::acceptConnection,
                                               this, conn_handler) );
     m_scheduler.add_active_user();
     m_accept_ready.wait(accept_lock);

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -9,14 +9,10 @@
 
 #include <asio.hpp>
 
-// #pragma diagnostic is only supported by GCC >= 4.2.1
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 2) || (__GNUC__ == 4 && __GNUC_MINOR__ == 2 && __GNUC_PATCHLEVEL__ >= 1)
-    #pragma GCC diagnostic ignored "-Wunused-parameter"
-    #include <boost/thread.hpp>
-    #pragma GCC diagnostic warning "-Wunused-parameter"
-#else
-    #include <boost/thread.hpp>
-#endif
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <thread>
+#pragma GCC diagnostic warning "-Wunused-parameter"
+
 
 #include <functional>
 #include <boost/test/unit_test.hpp>
@@ -62,7 +58,7 @@ public:
         // notify test thread that we are ready to accept a connection
         {
             // wait for test thread to be waiting on the signal
-            boost::unique_lock<std::mutex> accept_lock(m_accept_mutex);
+            std::unique_lock<std::mutex> accept_lock(m_accept_mutex);
             // trigger signal to wake test thread
             m_port = tcp_acceptor.local_endpoint().port();
             m_accept_ready.notify_one();

--- a/tests/tcp_stream_tests.cpp
+++ b/tests/tcp_stream_tests.cpp
@@ -18,7 +18,7 @@
     #include <boost/thread.hpp>
 #endif
 
-#include <boost/function.hpp>
+#include <functional>
 #include <boost/test/unit_test.hpp>
 #include <pion/config.hpp>
 #include <pion/scheduler.hpp>
@@ -62,7 +62,7 @@ public:
         // notify test thread that we are ready to accept a connection
         {
             // wait for test thread to be waiting on the signal
-            boost::unique_lock<boost::mutex> accept_lock(m_accept_mutex);
+            boost::unique_lock<std::mutex> accept_lock(m_accept_mutex);
             // trigger signal to wake test thread
             m_port = tcp_acceptor.local_endpoint().port();
             m_accept_ready.notify_one();
@@ -91,10 +91,10 @@ public:
     single_service_scheduler      m_scheduler;
 
     /// used to notify test thread when acceptConnection() is ready
-    boost::condition                m_accept_ready;
+    std::condition_variable                m_accept_ready;
     
     /// used to sync test thread with acceptConnection()
-    boost::mutex                    m_accept_mutex;
+    std::mutex                    m_accept_mutex;
 };
 
 
@@ -103,7 +103,7 @@ public:
 BOOST_FIXTURE_TEST_SUITE(tcp_stream_tests_S, tcp_stream_tests_F)
 
 BOOST_AUTO_TEST_CASE(checkTCPConnectToAnotherStream) {
-    boost::unique_lock<boost::mutex> accept_lock(m_accept_mutex);
+    std::unique_lock<std::mutex> accept_lock(m_accept_mutex);
 
     // schedule another thread to listen for a TCP connection
     connection_handler conn_handler(std::bind(&tcp_stream_tests_F::sendHello, std::placeholders::_1));
@@ -162,7 +162,7 @@ public:
 BOOST_FIXTURE_TEST_SUITE(tcp_stream_buffer_tests_S, tcp_stream_buffer_tests_F)
 
 BOOST_AUTO_TEST_CASE(checkSendAndReceiveBiggerThanBuffers) {
-    boost::unique_lock<boost::mutex> accept_lock(m_accept_mutex);
+    std::unique_lock<std::mutex> accept_lock(m_accept_mutex);
 
     // schedule another thread to listen for a TCP connection
     connection_handler conn_handler(std::bind(&tcp_stream_buffer_tests_F::sendBigBuffer, this, std::placeholders::_1));

--- a/utils/helloserver.cpp
+++ b/utils/helloserver.cpp
@@ -8,7 +8,7 @@
 //
 
 #include <iostream>
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <boost/bind.hpp>
 #include <pion/error.hpp>
 #include <pion/process.hpp>
@@ -27,8 +27,8 @@ public:
     {
         static const std::string HELLO_MESSAGE("Hello there!\x0D\x0A");
         tcp_conn->set_lifecycle(pion::tcp::connection::LIFECYCLE_CLOSE); // make sure it will get closed
-        tcp_conn->async_write(boost::asio::buffer(HELLO_MESSAGE),
-                              boost::bind(&pion::tcp::connection::finish, tcp_conn));
+        tcp_conn->async_write(asio::buffer(HELLO_MESSAGE),
+                              std::bind(&pion::tcp::connection::finish, tcp_conn));
     }
 };
 

--- a/utils/piond.cpp
+++ b/utils/piond.cpp
@@ -9,7 +9,7 @@
 
 #include <vector>
 #include <iostream>
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <pion/error.hpp>
 #include <pion/plugin.hpp>
 #include <pion/process.hpp>
@@ -46,7 +46,7 @@ int main (int argc, char *argv[])
     ServiceOptionsType service_options;
     
     // parse command line: determine port number, RESOURCE and WEBSERVICE
-    boost::asio::ip::tcp::endpoint cfg_endpoint(boost::asio::ip::tcp::v4(), DEFAULT_PORT);
+    asio::ip::tcp::endpoint cfg_endpoint(asio::ip::tcp::v4(), DEFAULT_PORT);
     std::string service_config_file;
     std::string resource_name;
     std::string service_name;
@@ -63,7 +63,7 @@ int main (int argc, char *argv[])
                 if (cfg_endpoint.port() == 0) cfg_endpoint.port(DEFAULT_PORT);
             } else if (argv[argnum][1] == 'i' && argv[argnum][2] == '\0' && argnum+1 < argc) {
                 // set ip address
-                cfg_endpoint.address(boost::asio::ip::address::from_string(argv[++argnum]));
+                cfg_endpoint.address(asio::ip::address::from_string(argv[++argnum]));
             } else if (argv[argnum][1] == 'c' && argv[argnum][2] == '\0' && argnum+1 < argc) {
                 service_config_file = argv[++argnum];
             } else if (argv[argnum][1] == 'd' && argv[argnum][2] == '\0' && argnum+1 < argc) {


### PR DESCRIPTION
Hi! For my project I had ported as much as possible boost-specific code to standard c++ library without changing any logic. It requires modern c++ std lib and standalone asio version. You can merge this changes in unstable branch if you wish(all tests are ok but not really sure that they cover 100% of functionality). If compatibility with old compilers is crucial then you can just ignore this request