### PR TITLE
Binary multipart

### DIFF
--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -328,17 +328,39 @@ public:
                                 const char *ptr, const std::size_t len);
 
     /**
-     * parse key-value pairs out of a multipart/form-data payload content
-     * (http://www.ietf.org/rfc/rfc2388.txt)
-     *
-     * @param dict dictionary for key-values pairs
-     * @param content_type value of the content-type HTTP header
-     * @param ptr points to the start of the encoded data
-     * @param len length of the encoded data, in bytes
-     *
+     * convert binary buffer to base64-encoded string with prefix signaled original stream MIME type
+     * @param out_val string for MIME encoded data
+     * @param buf points to the start of the binary data
+	 * @param buf_size size of the binary data
+	 * @param stream_type original stream MIME type
+	 *
      * @return bool true if successful
      */
-    static bool parse_multipart_form_data(ihash_multimap& dict,
+	static bool binary_2base64(std::string& out_val, const char *buf, const std::size_t buf_size, const std::string& stream_type);
+	/**
+	* convert base64-encoded string to binary buffer to with prefix signaled original stream MIME type
+	* @param out_buf buffer for MIME encoded data
+	* @param buf_size size of the input buffer for decoded data
+	* @param out_size required buffer size (in case return false) or used size of the buffer for decoded data
+	* @param out_stream_type original stream MIME type
+	* @param base64 encoded data
+	*
+	* @return bool true if successful
+	*/
+	static bool base64_2binary(char *out_buf, const std::size_t buf_size, std::size_t& out_size, std::string& out_stream_type, const std::string& base64);
+
+	/**
+	* parse key-value pairs out of a multipart/form-data payload content
+	* (http://www.ietf.org/rfc/rfc2388.txt)
+	*
+	* @param dict dictionary for key-values pairs
+	* @param content_type value of the content-type HTTP header
+	* @param ptr points to the start of the encoded data
+	* @param len length of the encoded data, in bytes
+	*
+	* @return bool true if successful
+	*/
+	static bool parse_multipart_form_data(ihash_multimap& dict,
                                           const std::string& content_type,
                                           const char *ptr, const std::size_t len);
     

--- a/include/pion/http/parser.hpp
+++ b/include/pion/http/parser.hpp
@@ -331,36 +331,36 @@ public:
      * convert binary buffer to base64-encoded string with prefix signaled original stream MIME type
      * @param out_val string for MIME encoded data
      * @param buf points to the start of the binary data
-	 * @param buf_size size of the binary data
-	 * @param stream_type original stream MIME type
-	 *
+     * @param buf_size size of the binary data
+     * @param stream_type original stream MIME type
+     *
      * @return bool true if successful
      */
-	static bool binary_2base64(std::string& out_val, const char *buf, const std::size_t buf_size, const std::string& stream_type);
-	/**
-	* convert base64-encoded string to binary buffer to with prefix signaled original stream MIME type
-	* @param out_buf buffer for MIME encoded data
-	* @param buf_size size of the input buffer for decoded data
-	* @param out_size required buffer size (in case return false) or used size of the buffer for decoded data
-	* @param out_stream_type original stream MIME type
-	* @param base64 encoded data
-	*
-	* @return bool true if successful
-	*/
-	static bool base64_2binary(char *out_buf, const std::size_t buf_size, std::size_t& out_size, std::string& out_stream_type, const std::string& base64);
+    static bool binary_2base64(std::string& out_val, const char *buf, const std::size_t buf_size, const std::string& stream_type);
+    /**
+    * convert base64-encoded string to binary buffer to with prefix signaled original stream MIME type
+    * @param out_buf buffer for MIME encoded data
+    * @param buf_size size of the input buffer for decoded data
+    * @param out_size required buffer size (in case return false) or used size of the buffer for decoded data
+    * @param out_stream_type original stream MIME type
+    * @param base64 encoded data
+    *
+    * @return bool true if successful
+    */
+    static bool base64_2binary(char *out_buf, const std::size_t buf_size, std::size_t& out_size, std::string& out_stream_type, const std::string& base64);
 
-	/**
-	* parse key-value pairs out of a multipart/form-data payload content
-	* (http://www.ietf.org/rfc/rfc2388.txt)
-	*
-	* @param dict dictionary for key-values pairs
-	* @param content_type value of the content-type HTTP header
-	* @param ptr points to the start of the encoded data
-	* @param len length of the encoded data, in bytes
-	*
-	* @return bool true if successful
-	*/
-	static bool parse_multipart_form_data(ihash_multimap& dict,
+    /**
+    * parse key-value pairs out of a multipart/form-data payload content
+    * (http://www.ietf.org/rfc/rfc2388.txt)
+    *
+    * @param dict dictionary for key-values pairs
+    * @param content_type value of the content-type HTTP header
+    * @param ptr points to the start of the encoded data
+    * @param len length of the encoded data, in bytes
+    *
+    * @return bool true if successful
+    */
+    static bool parse_multipart_form_data(ihash_multimap& dict,
                                           const std::string& content_type,
                                           const char *ptr, const std::size_t len);
     

--- a/src/http_parser.cpp
+++ b/src/http_parser.cpp
@@ -1053,7 +1053,7 @@ bool parser::base64_2binary(char *out_buf, const std::size_t buf_size, std::size
 
     char *p = std::copy(
         base64_2binary(base64.data() + prefix_end_pos),
-        base64_2binary(base64.data() + size - prefix_end_pos),
+        base64_2binary(base64.data() + size),
         out_buf
         );
     *p = '\0';

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(testParseMultipartFormData)
     http::parser::base64_2binary(buf, 256, size, content_type, i->second);
     BOOST_REQUIRE(size == 16);
     BOOST_CHECK_EQUAL(content_type, "application/octet-stream");
-    BOOST_CHECK_EQUAL(buf, "DO NOT SKIP ME!");
+    BOOST_CHECK_EQUAL(std::string(buf), "DO NOT SKIP ME!");
     
 
     i = params.find("field1");

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -280,9 +280,8 @@ BOOST_AUTO_TEST_CASE(testParseMultipartFormData)
     std::size_t size;
     std::string content_type;
     http::parser::base64_2binary(buf, 256, size, content_type, i->second);
-    BOOST_REQUIRE(size == 15);
+    BOOST_REQUIRE(size == 16);
     BOOST_CHECK_EQUAL(content_type, "application/octet-stream");
-    buf[size] = '\0';
     BOOST_CHECK_EQUAL(buf, "DO NOT SKIP ME!");
     
 

--- a/tests/http_parser_tests.cpp
+++ b/tests/http_parser_tests.cpp
@@ -259,10 +259,10 @@ BOOST_AUTO_TEST_CASE(testParseMultipartFormData)
                                 "\r\n"
                                 "a\r\n"
                                 "------WebKitFormBoundarynqrI4c1BfROrEpu7\r\n"
-                                "Content-Disposition: form-data; name=\"skipme\"\r\n"
+                                "Content-Disposition: form-data; name=\"donotskipme\"\r\n"
                                 "content-type: application/octet-stream\r\n"
                                 "\r\n"
-                                "SKIP ME!\r\n"
+                                "DO NOT SKIP ME!\r\n"
                                 "------WebKitFormBoundarynqrI4c1BfROrEpu7\r\n"
                                 "Content-Disposition: form-data; name=\"funny$field2\"\r\n"
                                 "\r\n"
@@ -270,11 +270,21 @@ BOOST_AUTO_TEST_CASE(testParseMultipartFormData)
                                 "------WebKitFormBoundarynqrI4c1BfROrEpu7--");
     ihash_multimap params;
     BOOST_REQUIRE(http::parser::parse_multipart_form_data(params, "multipart/form-data; boundary=----WebKitFormBoundarynqrI4c1BfROrEpu7", FORM_DATA));
-    BOOST_CHECK_EQUAL(params.size(), 4UL);
+    BOOST_CHECK_EQUAL(params.size(), 5UL);
     ihash_multimap::const_iterator i;
 
-    i = params.find("skipme");
-    BOOST_REQUIRE(i == params.end());
+    i = params.find("donotskipme");
+    BOOST_REQUIRE(i != params.end());
+    BOOST_CHECK_EQUAL(i->second.substr(0, 39), "data:application/octet-stream; base64, ");
+    char buf[256];
+    std::size_t size;
+    std::string content_type;
+    http::parser::base64_2binary(buf, 256, size, content_type, i->second);
+    BOOST_REQUIRE(size == 15);
+    BOOST_CHECK_EQUAL(content_type, "application/octet-stream");
+    buf[size] = '\0';
+    BOOST_CHECK_EQUAL(buf, "DO NOT SKIP ME!");
+    
 
     i = params.find("field1");
     BOOST_REQUIRE(i != params.end());


### PR DESCRIPTION
This patch allows to upload binary multipart/form-data streams to pion. Such streams will be stored as BASE64 encoded data. To restore original binary stream user may use provided function
parser::binary_2base64
I've fixed testbench errors and signed Splunk's CLA.