### PR TITLE
Fixed broken package configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,7 +141,7 @@ install(TARGETS ${PROJECT_NAME}
     )
 
 include(CMakePackageConfigHelpers)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/lib${PROJECT_NAME}-config.cmake.in
+configure_file(${PION_SRC_ROOT}/cmake/modules/lib${PROJECT_NAME}-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}-config.cmake
     @ONLY)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,7 +141,7 @@ install(TARGETS ${PROJECT_NAME}
     )
 
 include(CMakePackageConfigHelpers)
-configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/lib${PROJECT_NAME}-config.cmake.in
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/modules/lib${PROJECT_NAME}-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/lib${PROJECT_NAME}-config.cmake
     @ONLY)
 


### PR DESCRIPTION
Pion failed finding the file when being used as a submodule.

Steps to reproduce (tested on linux):
1. Create a new directory `foo`
2. Create `foo/CMakeLists.txt` that has `add_subdirectory("pion")` in it
3. clone pion in `foo` (so you get `foo/pion/...`)
4. Create `foo/Release`
5. cd into `foo/Release` and run cmake ..

This change makes the file being configured relative to the current directory `src/CMakeLists.txt` is placed in. Maybe `PION_SRC_ROOT` could have been used, however this is working aswell.
