### PR TITLE
Fixes for building with Android NDK

### DIFF
--- a/build/pion-setup.inc
+++ b/build/pion-setup.inc
@@ -100,6 +100,10 @@ case "$build_os" in
 	;;
 esac
 
+# Remove -lrt if building on android
+if test "${host#*android}" != "$host"; then
+    LIBS="-ldl"
+fi
 
 # Check for --with-cpu (gcc CPU architecture)
 AC_MSG_CHECKING([for specific CPU architecture])

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -16,6 +16,8 @@
     #include <fcntl.h>
     #include <unistd.h>
     #include <sys/stat.h>
+    #include <sys/time.h>
+    #include <sys/resource.h>
 #endif
 
 #include <boost/filesystem.hpp>
@@ -255,7 +257,9 @@ void process::daemonize(void)
     setsid();
     
     // close all descriptors
-    for (i=getdtablesize();i>=0;--i) close(i);
+    struct rlimit rlim;
+    getrlimit(RLIMIT_NOFILE, &rlim);
+    for (i=rlim.rlim_cur-1;i>=0;--i) close(i);
     
     // bind stdio to /dev/null (ignore errors)
     i=open("/dev/null",O_RDWR);


### PR DESCRIPTION
I'm attempting to build pion with the Android NDK, and I ran into a few issues with the build. First, librt doesn't exist on Android, so it needs to be removed from the LIBS variable during configure. Second, `getdtablesize` is deprecated and has been replaced with `getrlimit`.